### PR TITLE
FEATURE: Add create-migration wrapper script and update skill to use it

### DIFF
--- a/.claude/skills/create-migration/SKILL.md
+++ b/.claude/skills/create-migration/SKILL.md
@@ -2,20 +2,21 @@
 name: create-migration
 description: Create new SQL migration files for multiple database dialects (sqlite, mysql, etc.)
 disable-model-invocation: true
+allowed-tools: Bash
 argument-hint: [migration_name]
 ---
 
 Create new migration files named `$ARGUMENTS` for all configured database dialects.
 
-## Steps
+Run the wrapper script:
 
-1. Find all `rockhopper_*.yaml` config files in the project root to determine which dialects are configured.
-2. For each config file found, run:
-   ```bash
-   rockhopper --config <config_file> create --type sql $ARGUMENTS
-   ```
-3. List the newly created migration files and show their paths.
-4. Remind the user to edit both migration files since each dialect may need different SQL syntax.
+```bash
+bash scripts/create-migration.sh $ARGUMENTS
+```
+
+If the script is not found, fall back to finding all `rockhopper_*.yaml` config files and running `rockhopper --config <config> create --type sql $ARGUMENTS` for each.
+
+After creation, list the newly created files and remind the user to edit all migration files since each dialect may need different SQL syntax.
 
 ## Migration file format reference
 

--- a/scripts/create-migration.sh
+++ b/scripts/create-migration.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+usage() {
+    echo "Usage: $0 [-t type] <migration_name>"
+    echo ""
+    echo "Create migration files for all rockhopper_*.yaml configs found in the project root."
+    echo ""
+    echo "Options:"
+    echo "  -t type    Migration type (default: sql)"
+    echo ""
+    echo "Example:"
+    echo "  $0 add_pnl_column"
+    echo "  $0 -t sql add_trades_table"
+    exit 1
+}
+
+TYPE="sql"
+
+while getopts "t:h" opt; do
+    case $opt in
+        t) TYPE="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [ -z "$1" ]; then
+    echo "Error: migration name is required"
+    usage
+fi
+
+MIGRATION_NAME="$1"
+
+# Find project root by looking for go.mod
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+CONFIGS=$(find "$PROJECT_ROOT" -maxdepth 1 -name 'rockhopper_*.yaml' | sort)
+
+if [ -z "$CONFIGS" ]; then
+    echo "Error: no rockhopper_*.yaml config files found in $PROJECT_ROOT"
+    exit 1
+fi
+
+echo "Creating migration '$MIGRATION_NAME' (type: $TYPE)"
+echo ""
+
+for config in $CONFIGS; do
+    config_name=$(basename "$config")
+    echo ">> $config_name"
+    rockhopper --config "$config" create --type "$TYPE" "$MIGRATION_NAME"
+    echo ""
+done
+
+echo "Done. Remember to edit all migration files — SQL syntax may differ between dialects."


### PR DESCRIPTION
Script auto-discovers rockhopper_*.yaml configs and creates migration files for all dialects. Supports -t flag for type.