### PR TITLE
fix(sqlite3): migration sql string to include id

### DIFF
--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -45,7 +45,7 @@ func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB, tableName string) (*sql.Rows,
 }
 
 func (m Sqlite3Dialect) migrationSQL(tableName string) string {
-	return fmt.Sprintf("SELECT tstamp, is_applied FROM %s WHERE package = ? AND version_id = ? ORDER BY tstamp DESC LIMIT 1", tableName)
+	return fmt.Sprintf("SELECT id, tstamp, is_applied FROM %s WHERE package = ? AND version_id = ? ORDER BY tstamp DESC LIMIT 1", tableName)
 }
 
 func (m Sqlite3Dialect) deleteVersionSQL(tableName string) string {


### PR DESCRIPTION
- Issue: the postgres and mysql dialects already include `id` in their `migrationSQL()`, sqlite3 is not
- Error: `sql: expected 2 destination arguments in Scan, not 3`