### PR TITLE
FIX: [compile] register SQL as data so compiled migrations show their source

### DIFF
--- a/dumper.go
+++ b/dumper.go
@@ -139,42 +139,54 @@ func AddNamedMigration(packageName, filename string, up, down rockhopper.Transac
 	}
 
 	registeredGoMigrations[key] = migration
+}
+
+// AddStatementMigration registers a migration that was compiled from a .sql file.
+// The SQL statements are kept as data (rather than baked into a function body) so
+// the console can preview each statement while the migration runs.
+func AddStatementMigration(packageName string, version int64, source string, useTx bool, upStatements, downStatements []rockhopper.Statement) {
+	migration := &rockhopper.Migration{
+		Package:    packageName,
+		Registered: true,
+
+		Version: version,
+		Source:  source,
+		UseTx:   useTx,
+
+		UpStatements:   upStatements,
+		DownStatements: downStatements,
+	}
+
+	key := rockhopper.RegistryKey{ Package: packageName, Version: version}
+	if existing, ok := registeredGoMigrations[key]; ok {
+		panic(fmt.Sprintf("failed to add migration %q: version conflicts with key %+v: %+v", source, key, existing))
+	}
+
+	registeredGoMigrations[key] = migration
 }`))
 
 var migrationTemplate = template.Must(template.New("cmd.go-migration").Funcs(templateFuncs).Parse(`package {{.PackageName}}
 
 import (
-	"context"
-
 	"github.com/c9s/rockhopper/v2"
 )
 
+// This migration was compiled from {{ .Migration.Source }}.
+// The SQL statements are registered as data so they can be previewed in the
+// console while the migration runs, exactly like a raw .sql migration.
 func init() {
-	AddMigration({{ .Migration.Package | quote }}, up{{ .FuncNameBody }}, down{{ .FuncNameBody }})
-}
-
-func up{{ .FuncNameBody }}(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is applied.
+	AddStatementMigration({{ .Migration.Package | quote }}, {{ .Migration.Version }}, {{ .Migration.Source | quote }}, {{ .Migration.UseTx }},
+		[]rockhopper.Statement{
 {{- range .Migration.UpStatements }}
-	_, err = tx.ExecContext(ctx, {{ .SQL | quote }})
-	if err != nil {
-		return err
-	}
-
+			{Direction: rockhopper.DirectionUp, SQL: {{ .SQL | quote }}},
 {{- end }}
-	return err
-}
-
-func down{{ .FuncNameBody }}(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is rolled back.
+		},
+		[]rockhopper.Statement{
 {{- range .Migration.DownStatements }}
-	_, err = tx.ExecContext(ctx, {{ .SQL | quote }})
-	if err != nil {
-		return err
-	}
-
+			{Direction: rockhopper.DirectionDown, SQL: {{ .SQL | quote }}},
 {{- end }}
-	return err
+		},
+	)
 }`))
 
 type apiTemplateArgs struct {
@@ -201,13 +213,6 @@ func renderTemplateAndGoFormat(tpl *template.Template, a interface{}) ([]byte, e
 }
 
 type migrationTemplateArgs struct {
-	FuncNameBody string
-
-	CamelName string
-
-	// BaseName is the file basename of the migration script.
-	BaseName string
-
 	// Migration is the Migration metadata object
 	Migration *Migration
 
@@ -219,13 +224,9 @@ var specialCharsRegExp = regexp.MustCompile(`\W`)
 
 func renderMigration(packageName string, m *Migration) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
-	funcNameBody := "_" + specialCharsRegExp.ReplaceAllLiteralString(m.Package+"_"+toCamelCase(m.Name), "_")
 	err := migrationTemplate.Execute(buf, migrationTemplateArgs{
-		FuncNameBody: funcNameBody,
-		CamelName:    strings.ToTitle(toCamelCase(m.Name)),
-		BaseName:     filepath.Base(m.Source),
-		Migration:    m,
-		PackageName:  packageName,
+		Migration:   m,
+		PackageName: packageName,
 	})
 
 	if err != nil {

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -6,7 +6,42 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestRenderMigrationKeepsStatements guards that compiled migrations register
+// their SQL as data (so the console can preview each statement at runtime),
+// rather than baking the SQL into opaque up/down function bodies.
+func TestRenderMigrationKeepsStatements(t *testing.T) {
+	m := &Migration{
+		Package: "billing",
+		Name:    "create_invoices",
+		Version: 20200101000000,
+		Source:  "migrations/20200101000000_create_invoices.sql",
+		UseTx:   true,
+		UpStatements: []Statement{
+			{Direction: DirectionUp, SQL: "CREATE TABLE invoices (id INT PRIMARY KEY)"},
+		},
+		DownStatements: []Statement{
+			{Direction: DirectionDown, SQL: "DROP TABLE invoices"},
+		},
+	}
+
+	out, err := renderMigration("migrations", m)
+	require.NoError(t, err)
+
+	src := string(out)
+
+	// SQL is preserved as data so descMigration counts and the EXECUTING preview work.
+	assert.Contains(t, src, "AddStatementMigration")
+	assert.Contains(t, src, "rockhopper.DirectionUp")
+	assert.Contains(t, src, "CREATE TABLE invoices (id INT PRIMARY KEY)")
+	assert.Contains(t, src, "DROP TABLE invoices")
+
+	// the SQL must no longer be hidden inside generated function bodies
+	assert.NotContains(t, src, "func up")
+	assert.NotContains(t, src, "tx.ExecContext")
+}
 
 func TestMigrationDumper(t *testing.T) {
 	var loader SqlMigrationLoader

--- a/pkg/testing/migrations/app1_20240116231445_create_table_1.go
+++ b/pkg/testing/migrations/app1_20240116231445_create_table_1.go
@@ -1,38 +1,21 @@
 package migrations
 
 import (
-	"context"
-
 	"github.com/c9s/rockhopper/v2"
 )
 
+// This migration was compiled from migrations/mysql/app1/20240116231445_create_table_1.sql.
+// The SQL statements are registered as data so they can be previewed in the
+// console while the migration runs, exactly like a raw .sql migration.
 func init() {
-	AddMigration("app1", up_app1_createTable_1, down_app1_createTable_1)
-
-}
-
-func up_app1_createTable_1(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is applied.
-	_, err = tx.ExecContext(ctx, "CREATE TABLE app1_a\n(\n    `gid`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,\n    `id`             BIGINT UNSIGNED,\n    `order_id`       BIGINT UNSIGNED NOT NULL,\n    `exchange`       VARCHAR(24) NOT NULL DEFAULT '',\n    `symbol`         VARCHAR(20) NOT NULL,\n    `price`          DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quantity`       DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quote_quantity` DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee`            DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee_currency`   VARCHAR(10) NOT NULL,\n    `is_buyer`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_maker`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `side`           VARCHAR(4)  NOT NULL DEFAULT '',\n    `traded_at`      DATETIME(3) NOT NULL,\n    `is_margin`      BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_isolated`    BOOLEAN     NOT NULL DEFAULT FALSE,\n    `strategy`       VARCHAR(32) NULL,\n    `pnl`            DECIMAL NULL,\n    PRIMARY KEY (`gid`),\n    UNIQUE KEY `id` (`exchange`, `symbol`, `side`, `id`)\n);")
-	if err != nil {
-		return err
-	}
-	_, err = tx.ExecContext(ctx, "ALTER TABLE app1_a ADD COLUMN foo INT DEFAULT 0;")
-	if err != nil {
-		return err
-	}
-	return err
-}
-
-func down_app1_createTable_1(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is rolled back.
-	_, err = tx.ExecContext(ctx, "ALTER TABLE app1_a DROP COLUMN foo;")
-	if err != nil {
-		return err
-	}
-	_, err = tx.ExecContext(ctx, "DROP TABLE app1_a;")
-	if err != nil {
-		return err
-	}
-	return err
+	AddStatementMigration("app1", 20240116231445, "migrations/mysql/app1/20240116231445_create_table_1.sql", true,
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionUp, SQL: "CREATE TABLE app1_a\n(\n    `gid`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,\n    `id`             BIGINT UNSIGNED,\n    `order_id`       BIGINT UNSIGNED NOT NULL,\n    `exchange`       VARCHAR(24) NOT NULL DEFAULT '',\n    `symbol`         VARCHAR(20) NOT NULL,\n    `price`          DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quantity`       DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quote_quantity` DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee`            DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee_currency`   VARCHAR(10) NOT NULL,\n    `is_buyer`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_maker`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `side`           VARCHAR(4)  NOT NULL DEFAULT '',\n    `traded_at`      DATETIME(3) NOT NULL,\n    `is_margin`      BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_isolated`    BOOLEAN     NOT NULL DEFAULT FALSE,\n    `strategy`       VARCHAR(32) NULL,\n    `pnl`            DECIMAL NULL,\n    PRIMARY KEY (`gid`),\n    UNIQUE KEY `id` (`exchange`, `symbol`, `side`, `id`)\n);"},
+			{Direction: rockhopper.DirectionUp, SQL: "ALTER TABLE app1_a ADD COLUMN foo INT DEFAULT 0;"},
+		},
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionDown, SQL: "ALTER TABLE app1_a DROP COLUMN foo;"},
+			{Direction: rockhopper.DirectionDown, SQL: "DROP TABLE app1_a;"},
+		},
+	)
 }

--- a/pkg/testing/migrations/app1_20240116231513_create_table_2.go
+++ b/pkg/testing/migrations/app1_20240116231513_create_table_2.go
@@ -1,30 +1,19 @@
 package migrations
 
 import (
-	"context"
-
 	"github.com/c9s/rockhopper/v2"
 )
 
+// This migration was compiled from migrations/mysql/app1/20240116231513_create_table_2.sql.
+// The SQL statements are registered as data so they can be previewed in the
+// console while the migration runs, exactly like a raw .sql migration.
 func init() {
-	AddMigration("app1", up_app1_createTable_2, down_app1_createTable_2)
-
-}
-
-func up_app1_createTable_2(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is applied.
-	_, err = tx.ExecContext(ctx, "CREATE TABLE app1_b\n(\n    `gid`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,\n    `id`             BIGINT UNSIGNED,\n    `order_id`       BIGINT UNSIGNED NOT NULL,\n    `exchange`       VARCHAR(24) NOT NULL DEFAULT '',\n    `symbol`         VARCHAR(20) NOT NULL,\n    `price`          DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quantity`       DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quote_quantity` DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee`            DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee_currency`   VARCHAR(10) NOT NULL,\n    `is_buyer`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_maker`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `side`           VARCHAR(4)  NOT NULL DEFAULT '',\n    `traded_at`      DATETIME(3) NOT NULL,\n    `is_margin`      BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_isolated`    BOOLEAN     NOT NULL DEFAULT FALSE,\n    `strategy`       VARCHAR(32) NULL,\n    `pnl`            DECIMAL NULL,\n    PRIMARY KEY (`gid`),\n    UNIQUE KEY `id` (`exchange`, `symbol`, `side`, `id`)\n);")
-	if err != nil {
-		return err
-	}
-	return err
-}
-
-func down_app1_createTable_2(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is rolled back.
-	_, err = tx.ExecContext(ctx, "DROP TABLE app1_b;")
-	if err != nil {
-		return err
-	}
-	return err
+	AddStatementMigration("app1", 20240116231513, "migrations/mysql/app1/20240116231513_create_table_2.sql", true,
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionUp, SQL: "CREATE TABLE app1_b\n(\n    `gid`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,\n    `id`             BIGINT UNSIGNED,\n    `order_id`       BIGINT UNSIGNED NOT NULL,\n    `exchange`       VARCHAR(24) NOT NULL DEFAULT '',\n    `symbol`         VARCHAR(20) NOT NULL,\n    `price`          DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quantity`       DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `quote_quantity` DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee`            DECIMAL(16, 8) UNSIGNED NOT NULL,\n    `fee_currency`   VARCHAR(10) NOT NULL,\n    `is_buyer`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_maker`       BOOLEAN     NOT NULL DEFAULT FALSE,\n    `side`           VARCHAR(4)  NOT NULL DEFAULT '',\n    `traded_at`      DATETIME(3) NOT NULL,\n    `is_margin`      BOOLEAN     NOT NULL DEFAULT FALSE,\n    `is_isolated`    BOOLEAN     NOT NULL DEFAULT FALSE,\n    `strategy`       VARCHAR(32) NULL,\n    `pnl`            DECIMAL NULL,\n    PRIMARY KEY (`gid`),\n    UNIQUE KEY `id` (`exchange`, `symbol`, `side`, `id`)\n);"},
+		},
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionDown, SQL: "DROP TABLE app1_b;"},
+		},
+	)
 }

--- a/pkg/testing/migrations/app2_20240117132418_create_table_1.go
+++ b/pkg/testing/migrations/app2_20240117132418_create_table_1.go
@@ -1,30 +1,19 @@
 package migrations
 
 import (
-	"context"
-
 	"github.com/c9s/rockhopper/v2"
 )
 
+// This migration was compiled from migrations/mysql/app2/20240117132418_create_table_1.sql.
+// The SQL statements are registered as data so they can be previewed in the
+// console while the migration runs, exactly like a raw .sql migration.
 func init() {
-	AddMigration("app2", up_app2_createTable_1, down_app2_createTable_1)
-
-}
-
-func up_app2_createTable_1(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is applied.
-	_, err = tx.ExecContext(ctx, "CREATE TABLE app2_a(a int);")
-	if err != nil {
-		return err
-	}
-	return err
-}
-
-func down_app2_createTable_1(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is rolled back.
-	_, err = tx.ExecContext(ctx, "DROP TABLE app2_a;")
-	if err != nil {
-		return err
-	}
-	return err
+	AddStatementMigration("app2", 20240117132418, "migrations/mysql/app2/20240117132418_create_table_1.sql", true,
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionUp, SQL: "CREATE TABLE app2_a(a int);"},
+		},
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionDown, SQL: "DROP TABLE app2_a;"},
+		},
+	)
 }

--- a/pkg/testing/migrations/app2_20240117132421_create_table_2.go
+++ b/pkg/testing/migrations/app2_20240117132421_create_table_2.go
@@ -1,30 +1,19 @@
 package migrations
 
 import (
-	"context"
-
 	"github.com/c9s/rockhopper/v2"
 )
 
+// This migration was compiled from migrations/mysql/app2/20240117132421_create_table_2.sql.
+// The SQL statements are registered as data so they can be previewed in the
+// console while the migration runs, exactly like a raw .sql migration.
 func init() {
-	AddMigration("app2", up_app2_createTable_2, down_app2_createTable_2)
-
-}
-
-func up_app2_createTable_2(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is applied.
-	_, err = tx.ExecContext(ctx, "CREATE TABLE app2_b(a int);")
-	if err != nil {
-		return err
-	}
-	return err
-}
-
-func down_app2_createTable_2(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
-	// This code is executed when the migration is rolled back.
-	_, err = tx.ExecContext(ctx, "DROP TABLE app2_b;")
-	if err != nil {
-		return err
-	}
-	return err
+	AddStatementMigration("app2", 20240117132421, "migrations/mysql/app2/20240117132421_create_table_2.sql", true,
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionUp, SQL: "CREATE TABLE app2_b(a int);"},
+		},
+		[]rockhopper.Statement{
+			{Direction: rockhopper.DirectionDown, SQL: "DROP TABLE app2_b;"},
+		},
+	)
 }

--- a/pkg/testing/migrations/migration_api.go
+++ b/pkg/testing/migrations/migration_api.go
@@ -9,14 +9,9 @@ import (
 	"github.com/c9s/rockhopper/v2"
 )
 
-type registryKey struct {
-	Package string
-	Version int64
-}
+var registeredGoMigrations = map[rockhopper.RegistryKey]*rockhopper.Migration{}
 
-var registeredGoMigrations = map[registryKey]*rockhopper.Migration{}
-
-func MergeMigrationsMap(ms map[registryKey]*rockhopper.Migration) {
+func MergeMigrationsMap(ms map[rockhopper.RegistryKey]*rockhopper.Migration) {
 	for k, m := range ms {
 		if _, ok := registeredGoMigrations[k]; !ok {
 			registeredGoMigrations[k] = m
@@ -26,7 +21,7 @@ func MergeMigrationsMap(ms map[registryKey]*rockhopper.Migration) {
 	}
 }
 
-func GetMigrationsMap() map[registryKey]*rockhopper.Migration {
+func GetMigrationsMap() map[rockhopper.RegistryKey]*rockhopper.Migration {
 	return registeredGoMigrations
 }
 
@@ -71,10 +66,6 @@ func _parseFuncPackageName(funcName string) string {
 
 // AddNamedMigration adds a named migration to the registered go migration map
 func AddNamedMigration(packageName, filename string, up, down rockhopper.TransactionHandler) {
-	if registeredGoMigrations == nil {
-		registeredGoMigrations = make(map[registryKey]*rockhopper.Migration)
-	}
-
 	v, err := rockhopper.FileNumericComponent(filename)
 	if err != nil {
 		panic(fmt.Errorf("unable to parse numeric component from filename %s: %v", filename, err))
@@ -91,9 +82,33 @@ func AddNamedMigration(packageName, filename string, up, down rockhopper.Transac
 		UseTx:   true,
 	}
 
-	key := registryKey{Package: packageName, Version: v}
+	key := rockhopper.RegistryKey{Package: packageName, Version: v}
 	if existing, ok := registeredGoMigrations[key]; ok {
 		panic(fmt.Sprintf("failed to add migration %q: version conflicts with key %+v: %+v", filename, key, existing))
+	}
+
+	registeredGoMigrations[key] = migration
+}
+
+// AddStatementMigration registers a migration that was compiled from a .sql file.
+// The SQL statements are kept as data (rather than baked into a function body) so
+// the console can preview each statement while the migration runs.
+func AddStatementMigration(packageName string, version int64, source string, useTx bool, upStatements, downStatements []rockhopper.Statement) {
+	migration := &rockhopper.Migration{
+		Package:    packageName,
+		Registered: true,
+
+		Version: version,
+		Source:  source,
+		UseTx:   useTx,
+
+		UpStatements:   upStatements,
+		DownStatements: downStatements,
+	}
+
+	key := rockhopper.RegistryKey{Package: packageName, Version: version}
+	if existing, ok := registeredGoMigrations[key]; ok {
+		panic(fmt.Sprintf("failed to add migration %q: version conflicts with key %+v: %+v", source, key, existing))
 	}
 
 	registeredGoMigrations[key] = migration

--- a/pkg/testing/migrations/migration_api_test.go
+++ b/pkg/testing/migrations/migration_api_test.go
@@ -14,7 +14,7 @@ func TestGetMigrationsMap(t *testing.T) {
 }
 
 func TestMergeMigrationsMap(t *testing.T) {
-	MergeMigrationsMap(map[registryKey]*rockhopper.Migration{
+	MergeMigrationsMap(map[rockhopper.RegistryKey]*rockhopper.Migration{
 		{Version: 2}: {},
 		{Version: 3}: {},
 	})


### PR DESCRIPTION
Compiled SQL->Go migrations baked each statement into the body of generated up/down functions and registered them via UpFn/DownFn, leaving UpStatements/DownStatements empty. At runtime this meant descMigration printed "0 upgrade statements / 0 downgrade statements" and the per-statement "EXECUTING: <sql>" preview never appeared, because execution bypassed the executeStatements path.

Generate AddStatementMigration(...) instead, which registers the SQL as []rockhopper.Statement data with no UpFn/DownFn. Compiled migrations now run through the same executor as raw .sql migrations, so statement counts and the EXECUTING preview work identically.

Regenerated the pkg/testing/migrations sample to the new format and added TestRenderMigrationKeepsStatements to guard against regressing to function-body codegen.