### PR TITLE
FEATURE: [up] reject out-of-order migrations by default (--allow-out-of-order to opt in)

### DIFF
--- a/.claude/skills/apply-migrations/SKILL.md
+++ b/.claude/skills/apply-migrations/SKILL.md
@@ -16,6 +16,16 @@ Apply pending migrations using rockhopper.
    ```
 3. Report the result.
 
+## Handling out-of-order migrations
+
+If `up` fails with an "out-of-order migrations detected" error, it means a pending migration has a lower version than one that is already applied (common after merging parallel branches). Do **not** blindly re-run with `--allow-out-of-order`. Instead:
+
+1. Show the user the offending migration(s) from the error.
+2. Explain the two options:
+   - **Renumber** the new migration above the latest applied version (safe default — keeps history linear).
+   - **Apply in place** with `rockhopper --config <config_file> up --allow-out-of-order`, only if the older migration is independent of the newer ones.
+3. Ask the user which they prefer before proceeding.
+
 ## Environment variable overrides
 
 If the user needs to override the DSN or driver, remind them they can set:

--- a/README.md
+++ b/README.md
@@ -130,15 +130,37 @@ rockhopper redo
 ### `up` — Apply pending migrations
 
 ```sh
-rockhopper up                # apply all pending migrations
-rockhopper up --steps 3      # apply the next 3 pending migrations
-rockhopper up --to 20240117  # apply up to a specific version
+rockhopper up                       # apply all pending migrations
+rockhopper up --steps 3             # apply the next 3 pending migrations
+rockhopper up --to 20240117         # apply up to a specific version
+rockhopper up --allow-out-of-order  # also apply pending migrations older than the latest applied
 ```
 
 | Flag | Description |
 |---|---|
 | `--steps` | Number of migrations to apply |
 | `--to` | Target version to migrate up to |
+| `--allow-out-of-order` | Apply pending migrations whose version is below an already-applied migration |
+
+#### Out-of-order migrations
+
+When you work on parallel branches, a teammate can merge a migration with a
+timestamp *lower* than one you have already applied. By default `up` **refuses**
+to run in this situation and lists the offending files, because a normal upgrade
+walks forward from the last applied migration and would silently skip them:
+
+```
+out-of-order migrations detected in package "main": the following are pending but
+have a lower version than the highest applied migration (20240103000000), so a
+normal upgrade would silently skip them:
+  - 20240102000000  migrations/20240102000000_b.sql
+re-run with --allow-out-of-order to apply them anyway, or renumber them above the latest applied version
+```
+
+You then have two choices:
+
+- **Renumber** the new migration so its version is above the latest applied one (the safe default — history stays linear).
+- **Apply it in place** with `rockhopper up --allow-out-of-order`. Rockhopper warns for each out-of-order migration and applies it. Use this only when the older migration is independent of the newer ones, since it changes the applied order.
 
 ### `down` — Roll back migrations
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,90 @@
+# Rockhopper Roadmap
+
+A living checklist of where rockhopper is headed. Grouped by theme and roughly
+ordered by priority. Checkboxes are for tracking — tick them as work lands.
+
+**Framing:** rockhopper's unique selling point is *embeddable + AI-native*. The
+**Correctness & Safety** items make it safe to recommend in production; the
+**AI & Ecosystem** items make it the obvious choice for AI-assisted teams. Invest
+in both; let the parity features follow demand.
+
+## Suggested sequencing
+
+1. **Quick wins** — small bug fixes and doc corrections (section F).
+2. **The safety trio** — advisory locking → checksums → out-of-order policy (section A).
+3. **Lean into the differentiator** — `--dry-run` + `validate`, then the MCP server and plugin packaging (sections C & D).
+4. **Parity features** follow demand (section E).
+
+---
+
+## A. Correctness & safety (highest priority)
+
+What separates "works on my machine" from "trusted in production".
+
+- [ ] **Concurrency lock.** No serialization exists today (no advisory lock in the
+      codebase). On a rolling deploy, multiple instances boot and call `Up()`
+      simultaneously. Add per-dialect locking: Postgres `pg_advisory_lock`,
+      MySQL `GET_LOCK`, etc. *Most important missing feature for real deployments.*
+- [ ] **Checksum / drift detection.** Nothing hashes migration bodies, so editing
+      an already-applied migration goes unnoticed. Store a content hash in
+      `rockhopper_versions` and verify on load (Flyway / golang-migrate both do this).
+- [x] **Out-of-order migration policy.** `up` now detects pending migrations whose
+      version is below the highest applied version (`DB.InspectMigrations`) and
+      **rejects by default** with an actionable `OutOfOrderError`. Opt in with
+      `rockhopper up --allow-out-of-order` to apply them in place (with a warning).
+      Follow-up: apply the same guard to the library `Upgrade()` path and surface
+      out-of-order migrations in `status`.
+- [ ] **Duplicate version handling.** `MigrationSlice.Less` (`migration.go`) panics on
+      equal versions. Two branches generating migrations in the same second is
+      realistic. Replace the panic with a graceful error; consider collision
+      detection in `create`.
+
+## B. Dialect coverage & testing
+
+- [ ] **Decide MSSQL's fate.** Advertised in `CLAUDE.md` but not wired — there is no
+      `DialectMSSQL`, and `Open()` only allows postgres/sqlite3/mysql. Either
+      implement it or remove the claim (see section F).
+- [ ] **Generalize DSN-from-env.** `BuildDSNFromEnvVars` only supports MySQL. Extend
+      to a per-dialect DSN builder (builds on the recent `MYSQL8_` prefix work).
+- [ ] **Real-database integration tests.** Tests are SQLite-in-memory only. Add
+      container-based tests against real MySQL/Postgres — especially before adding
+      locking, which is inherently dialect-specific.
+
+## C. Operator / developer experience
+
+- [ ] **`--dry-run`** for `up`/`down` — print the SQL it *would* run without executing.
+      High value, and pairs naturally with the AI skills.
+- [ ] **`validate` / `lint` command** — detect duplicate versions, missing `-- +down`,
+      and parse errors *before* hitting them mid-deploy.
+- [ ] **Machine-readable `status` (`--json`)** for CI gates.
+- [ ] **Rollback ergonomics** — warn when a migration has no `-- +down` instead of
+      silently no-op'ing.
+
+## D. AI & ecosystem (widen the lead)
+
+- [ ] **MCP server (`rockhopper mcp`)** — expose status/up/down/create/compile as
+      structured tools so *any* agent can drive rockhopper, not just Claude Code.
+      Safer than shell parsing.
+- [ ] **Package skills as a Claude Code plugin / marketplace.** The `skills install`
+      scaffolder is the project-local tier; a plugin is the global/discoverable tier.
+- [ ] **Higher-value skills:**
+  - [ ] "Diagnose a failed migration"
+  - [ ] "Generate a migration from a schema diff"
+  - [ ] "Review this migration for footguns (locking DDL, non-`CONCURRENTLY` indexes)"
+
+## E. Parity features (lower priority)
+
+- [ ] **Repeatable migrations** — re-run on checksum change for views / procedures /
+      seed data (Flyway's `R__` concept).
+- [ ] **Baseline** — adopt rockhopper on an existing database. `align` covers part of
+      this but isn't framed as a baseline workflow.
+
+## F. Quick wins (do first)
+
+- [ ] **`config.TableName` is ignored.** It's parsed from YAML but `OpenWithConfig`
+      (`db.go`) always passes the `TableName` constant. Either wire it through or
+      drop the field. (Docs already note the CLI uses the default table name.)
+- [ ] **MSSQL doc mismatch.** `CLAUDE.md` lists MSSQL as supported; the code doesn't
+      wire it. Align docs with reality (or implement — see section B).
+- [ ] **Remove leftover debug print.** `fmt.Println("preRunE")` in
+      `cmd/rockhopper/main.go`.

--- a/cmd/rockhopper/up.go
+++ b/cmd/rockhopper/up.go
@@ -14,6 +14,7 @@ var log = logrus.WithField("application", "rockhopper")
 func init() {
 	UpCmd.Flags().Int64("to", 0, "up to a specific version")
 	UpCmd.Flags().Int("steps", 0, "run upgrade by steps")
+	UpCmd.Flags().Bool("allow-out-of-order", false, "apply pending migrations whose version is below an already-applied migration")
 	rootCmd.AddCommand(UpCmd)
 }
 
@@ -40,6 +41,11 @@ func up(cmd *cobra.Command, args []string) error {
 	}
 
 	to, err := cmd.Flags().GetInt64("to")
+	if err != nil {
+		return err
+	}
+
+	allowOutOfOrder, err := cmd.Flags().GetBool("allow-out-of-order")
 	if err != nil {
 		return err
 	}
@@ -78,35 +84,57 @@ func up(cmd *cobra.Command, args []string) error {
 	migrationMap = migrationMap.SortAndConnect()
 
 	for pkgName, migrations := range migrationMap {
-		_ = pkgName
-
-		_, lastAppliedMigration, err := db.FindLastAppliedMigration(ctx, migrations)
+		status, err := db.InspectMigrations(ctx, migrations)
 		if err != nil {
 			return err
 		}
 
-		startMigration := migrations.Head()
-		if lastAppliedMigration != nil {
-			startMigration = lastAppliedMigration.Next
-		}
-
-		if steps > 0 {
-			err = rockhopper.UpBySteps(ctx, db, startMigration, steps, func(m *rockhopper.Migration) {
-				// log.Infof("migration %v is applied", m.Version)
-			})
-			if err != nil {
-				return err
+		if len(status.OutOfOrder) > 0 {
+			if !allowOutOfOrder {
+				return &rockhopper.OutOfOrderError{
+					Package:               pkgName,
+					HighestAppliedVersion: status.HighestAppliedVersion,
+					Migrations:            status.OutOfOrder,
+				}
 			}
-		} else {
-			err = rockhopper.Up(ctx, db, startMigration, to, func(m *rockhopper.Migration) {
-				// log.Infof("migration %d is applied", m.Version)
-			})
-			if err != nil {
-				return err
+
+			for _, m := range status.OutOfOrder {
+				log.Warnf("applying out-of-order migration %d (%s); it is older than the already-applied version %d",
+					m.Version, m.Source, status.HighestAppliedVersion)
 			}
 		}
 
+		target := selectPending(status.Pending, steps, to)
+		if err := rockhopper.UpMigrations(ctx, db, target); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+// selectPending narrows the pending migrations down to those that should be applied
+// for this run. steps takes precedence over to: with steps > 0 it returns at most
+// that many migrations; otherwise with to > 0 it returns those at or below the
+// target version. The slice is assumed to be in ascending version order.
+func selectPending(pending rockhopper.MigrationSlice, steps int, to int64) rockhopper.MigrationSlice {
+	if steps > 0 {
+		if steps < len(pending) {
+			return pending[:steps]
+		}
+		return pending
+	}
+
+	if to > 0 {
+		var selected rockhopper.MigrationSlice
+		for _, m := range pending {
+			if m.Version > to {
+				break
+			}
+			selected = append(selected, m)
+		}
+		return selected
+	}
+
+	return pending
 }

--- a/db.go
+++ b/db.go
@@ -439,3 +439,54 @@ func (db *DB) FindLastAppliedMigration(
 
 	return -1, nil, nil
 }
+
+// MigrationStatus summarizes the applied state of a set of migrations.
+type MigrationStatus struct {
+	// Pending holds the migrations that have not been applied yet, in the order
+	// they appear in the inspected slice (ascending version when sorted).
+	Pending MigrationSlice
+
+	// OutOfOrder holds the subset of Pending whose version is lower than the
+	// highest already-applied version. A resume-from-last-applied upgrade walks
+	// forward from the last applied migration and would silently skip these.
+	OutOfOrder MigrationSlice
+
+	// HighestAppliedVersion is the highest version that has been applied, or 0
+	// when nothing has been applied yet.
+	HighestAppliedVersion int64
+}
+
+// InspectMigrations loads the applied state for every migration in the slice and
+// reports which migrations are pending and which of those are out of order. The
+// slice is expected to be sorted in ascending version order (as produced by
+// SortAndConnect); detection itself does not depend on the ordering.
+func (db *DB) InspectMigrations(ctx context.Context, migrations MigrationSlice) (*MigrationStatus, error) {
+	status := &MigrationStatus{}
+
+	for _, m := range migrations {
+		// reset any stale record before loading so a not-found lookup is treated as pending
+		m.Record = nil
+
+		if _, err := db.LoadMigration(ctx, m); err != nil {
+			return nil, err
+		}
+
+		if m.Record != nil && m.Record.IsApplied && m.Version > status.HighestAppliedVersion {
+			status.HighestAppliedVersion = m.Version
+		}
+	}
+
+	for _, m := range migrations {
+		if m.Record != nil && m.Record.IsApplied {
+			continue
+		}
+
+		status.Pending = append(status.Pending, m)
+
+		if m.Version < status.HighestAppliedVersion {
+			status.OutOfOrder = append(status.OutOfOrder, m)
+		}
+	}
+
+	return status, nil
+}

--- a/outoforder.go
+++ b/outoforder.go
@@ -1,0 +1,37 @@
+package rockhopper
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OutOfOrderError is returned when an upgrade finds pending migrations whose
+// version is lower than the highest already-applied migration. Applying them
+// would change history out of order, so rockhopper refuses by default and asks
+// the operator to opt in explicitly.
+type OutOfOrderError struct {
+	// Package is the migration package the out-of-order migrations belong to.
+	Package string
+
+	// HighestAppliedVersion is the highest version that has already been applied.
+	HighestAppliedVersion int64
+
+	// Migrations holds the offending pending migrations, in ascending version order.
+	Migrations MigrationSlice
+}
+
+func (e *OutOfOrderError) Error() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b,
+		"out-of-order migrations detected in package %q: the following are pending but have a lower version than the highest applied migration (%d), so a normal upgrade would silently skip them:\n",
+		e.Package, e.HighestAppliedVersion)
+
+	for _, m := range e.Migrations {
+		fmt.Fprintf(&b, "  - %d  %s\n", m.Version, m.Source)
+	}
+
+	b.WriteString("re-run with --allow-out-of-order to apply them anyway, or renumber them above the latest applied version")
+
+	return b.String()
+}

--- a/outoforder_test.go
+++ b/outoforder_test.go
@@ -1,0 +1,136 @@
+package rockhopper
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMigration(version int64, createSQL, dropSQL string) *Migration {
+	return &Migration{
+		Package:        "main",
+		Version:        version,
+		Source:         "migrations/main/test.sql",
+		UseTx:          true,
+		UpStatements:   []Statement{{Direction: DirectionUp, SQL: createSQL}},
+		DownStatements: []Statement{{Direction: DirectionDown, SQL: dropSQL}},
+	}
+}
+
+func openTestDB(t *testing.T) *DB {
+	t.Helper()
+
+	dialect, err := LoadDialect("sqlite3")
+	require.NoError(t, err)
+
+	db, err := Open("sqlite3", dialect, ":memory:", TableName)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.NoError(t, db.Touch(context.Background()))
+	return db
+}
+
+// TestInspectMigrations_DetectsOutOfOrder simulates a teammate merging a migration
+// with a version below one that is already applied, and asserts it is reported as
+// pending *and* out of order (the silent-skip hazard).
+func TestInspectMigrations_DetectsOutOfOrder(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	v1 := newTestMigration(20240101000000, "CREATE TABLE t1 (id INT)", "DROP TABLE t1")
+	v2 := newTestMigration(20240102000000, "CREATE TABLE t2 (id INT)", "DROP TABLE t2")
+	v3 := newTestMigration(20240103000000, "CREATE TABLE t3 (id INT)", "DROP TABLE t3")
+
+	// v2 does not exist yet: apply v1 and v3.
+	require.NoError(t, UpMigrations(ctx, db, MigrationSlice{v1, v3}))
+
+	// v2 is merged later; inspect the full set.
+	full := MigrationSlice{v1, v2, v3}.SortAndConnect()
+	status, err := db.InspectMigrations(ctx, full)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(20240103000000), status.HighestAppliedVersion)
+	require.Len(t, status.Pending, 1)
+	assert.Equal(t, int64(20240102000000), status.Pending[0].Version)
+	require.Len(t, status.OutOfOrder, 1)
+	assert.Equal(t, int64(20240102000000), status.OutOfOrder[0].Version)
+
+	// The typed error should carry the offending migration and be actionable.
+	ooErr := &OutOfOrderError{
+		Package:               "main",
+		HighestAppliedVersion: status.HighestAppliedVersion,
+		Migrations:            status.OutOfOrder,
+	}
+	msg := ooErr.Error()
+	assert.Contains(t, msg, "out-of-order")
+	assert.Contains(t, msg, "20240102000000")
+	assert.Contains(t, msg, "--allow-out-of-order")
+
+	// Applying the out-of-order migration clears the hazard.
+	require.NoError(t, UpMigrations(ctx, db, status.OutOfOrder))
+
+	status2, err := db.InspectMigrations(ctx, full)
+	require.NoError(t, err)
+	assert.Empty(t, status2.Pending)
+	assert.Empty(t, status2.OutOfOrder)
+}
+
+// TestInspectMigrations_InOrderHasNoFalsePositive ensures a normal forward sequence
+// (pending migrations all above the highest applied) is never flagged out of order.
+func TestInspectMigrations_InOrderHasNoFalsePositive(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	v1 := newTestMigration(20240101000000, "CREATE TABLE t1 (id INT)", "DROP TABLE t1")
+	v2 := newTestMigration(20240102000000, "CREATE TABLE t2 (id INT)", "DROP TABLE t2")
+	v3 := newTestMigration(20240103000000, "CREATE TABLE t3 (id INT)", "DROP TABLE t3")
+
+	require.NoError(t, UpMigrations(ctx, db, MigrationSlice{v1}))
+
+	full := MigrationSlice{v1, v2, v3}.SortAndConnect()
+	status, err := db.InspectMigrations(ctx, full)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(20240101000000), status.HighestAppliedVersion)
+	assert.Equal(t, []int64{20240102000000, 20240103000000}, status.Pending.Versions())
+	assert.Empty(t, status.OutOfOrder, "forward-only pending migrations must not be flagged out of order")
+}
+
+// TestInspectMigrations_NothingApplied treats every migration as pending and never
+// out of order when the database is empty.
+func TestInspectMigrations_NothingApplied(t *testing.T) {
+	ctx := context.Background()
+	db := openTestDB(t)
+
+	full := MigrationSlice{
+		newTestMigration(20240101000000, "CREATE TABLE t1 (id INT)", "DROP TABLE t1"),
+		newTestMigration(20240102000000, "CREATE TABLE t2 (id INT)", "DROP TABLE t2"),
+	}.SortAndConnect()
+
+	status, err := db.InspectMigrations(ctx, full)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), status.HighestAppliedVersion)
+	assert.Len(t, status.Pending, 2)
+	assert.Empty(t, status.OutOfOrder)
+}
+
+func TestOutOfOrderError_Message(t *testing.T) {
+	err := &OutOfOrderError{
+		Package:               "billing",
+		HighestAppliedVersion: 20240105000000,
+		Migrations: MigrationSlice{
+			newTestMigration(20240102000000, "", ""),
+		},
+	}
+
+	msg := err.Error()
+	assert.True(t, strings.Contains(msg, "billing"))
+	assert.True(t, strings.Contains(msg, "20240105000000"))
+	assert.True(t, strings.Contains(msg, "20240102000000"))
+}

--- a/up.go
+++ b/up.go
@@ -4,6 +4,34 @@ import (
 	"context"
 )
 
+// UpMigrations applies the given migrations in slice order. The migrations are
+// expected to be pending (not yet applied) and sorted in ascending version order;
+// any migration already marked as applied is skipped defensively.
+//
+// Unlike Up, which walks the Next linked-list pointers starting from a single
+// migration, UpMigrations applies exactly the migrations in the slice. This makes
+// it possible to apply out-of-order migrations — pending migrations whose version
+// is lower than an already-applied one — which a Next-pointer walk would skip.
+func UpMigrations(ctx context.Context, db *DB, migrations MigrationSlice, callbacks ...func(m *Migration)) error {
+	for _, m := range migrations {
+		if m.Record != nil && m.Record.IsApplied {
+			continue
+		}
+
+		descMigration("upgrading", m)
+
+		if err := m.Up(ctx, db); err != nil {
+			return err
+		}
+
+		for _, cb := range callbacks {
+			cb(m)
+		}
+	}
+
+	return nil
+}
+
 func UpBySteps(ctx context.Context, db *DB, m *Migration, steps int, callbacks ...func(m *Migration)) error {
 	for ; steps > 0 && m != nil; m = m.Next {
 		descMigration("upgrading", m)


### PR DESCRIPTION
## Problem

A migration merged with a timestamp **below** one that's already applied (normal with parallel branches) used to sit as `pending` forever. `FindLastAppliedMigration` scans from the highest version down and `Up` resumes from `lastApplied.Next`, so a `Next`-pointer walk never reaches the gap migration — it was **silently skipped**, a quiet data-correctness hazard.

## Change

`rockhopper up` now inspects the full applied state and **rejects by default** when it finds pending migrations below the highest applied version, with an actionable error:

```
out-of-order migrations detected in package "main": the following are pending but
have a lower version than the highest applied migration (20240103000000), so a
normal upgrade would silently skip them:
  - 20240102000000  migrations/20240102000000_b.sql
re-run with --allow-out-of-order to apply them anyway, or renumber them above the latest applied version
```

Pass `--allow-out-of-order` to apply them in place (with a per-migration warning).

### New library primitives (reusable by embedders)
- `DB.InspectMigrations(ctx, migrations)` → `*MigrationStatus{ Pending, OutOfOrder, HighestAppliedVersion }` — the detection
- `UpMigrations(ctx, db, slice)` — applies a pending slice directly; unlike `Up`, it doesn't walk `Next`, so it can reach gap migrations
- `OutOfOrderError` — typed, actionable error

### CLI
- `cmd/rockhopper/up.go` now inspects → guards → applies; added the `--allow-out-of-order` flag and a `selectPending` helper that preserves the existing `--steps` / `--to` semantics

### Docs & ecosystem
- README `up` section documents the flag, the real error output, and the renumber-vs-apply guidance
- The `apply-migrations` Claude Code skill now surfaces the choice instead of blindly forcing
- `ROADMAP.md` added; item A.3 checked off. Follow-ups noted: apply the same guard to the library `Upgrade()` path and flag out-of-order rows in `status`

## Testing
- Unit tests: detection, no-false-positive on forward-only sequences, empty DB, error message
- End-to-end CLI: applied v1+v3, merged v2 → default `up` rejected; `--allow-out-of-order` warned + applied v2; `status` confirmed all applied; re-run clean
- `go build`, `go test ./...`, `go vet`, `gofmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)