### PR TITLE
FEATURE: [config] expand $VAR / ${VAR} environment references in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,35 @@ includePackages:                 # Optional: only include these packages
 
 > The version-tracking table is always named `rockhopper_versions` when using the CLI. To use a custom table name, call the library's `Open` / `New` functions directly and pass your own name (see [Go API](#go-api)).
 
+### Environment variables in the config file
+
+Values in the config file may reference environment variables using `$VAR` or
+`${VAR}` syntax. They are expanded when the file is loaded, which is handy for
+keeping connection strings and secrets out of version control:
+
+```yaml
+---
+driver: mysql
+dialect: mysql
+dsn: ${MYSQL8_URL}        # expanded from the MYSQL8_URL environment variable
+migrationsDirs:
+- migrations/myapp
+```
+
+```sh
+export MYSQL8_URL="root:secret@tcp(localhost:3306)/myapp?parseTime=true"
+rockhopper up
+```
+
+Notes:
+
+- Both `${VAR}` and bare `$VAR` are supported.
+- An undefined variable expands to an empty string.
+- To keep a literal dollar sign in a value (e.g. inside a password), write `$$`.
+- This is independent of the `ROCKHOPPER_*` overrides below: if both are set,
+  the `ROCKHOPPER_*` environment variable still takes precedence over the file
+  value (see [Environment Variables](#environment-variables)).
+
 ## SQL Migration Format
 
 A simple migration:

--- a/config.go
+++ b/config.go
@@ -30,6 +30,16 @@ func LoadConfig(configFile string) (*Config, error) {
 		return nil, err
 	}
 
+	// Expand environment variables referenced in the config file before parsing,
+	// so values can be pulled from the environment, e.g.:
+	//
+	//   dsn: ${MYSQL8_URL}
+	//   dsn: $MYSQL8_URL
+	//
+	// Both $VAR and ${VAR} forms are supported. Undefined variables expand to an
+	// empty string (same as os.ExpandEnv). A literal '$' can be escaped as '$$'.
+	data = []byte(expandEnv(string(data)))
+
 	var config Config
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, err
@@ -44,4 +54,18 @@ func LoadConfig(configFile string) (*Config, error) {
 	}
 
 	return &config, err
+}
+
+// expandEnv replaces $VAR and ${VAR} references in s with the values of the
+// corresponding environment variables. It behaves like os.ExpandEnv, with one
+// addition: "$$" expands to a literal "$" so values that legitimately contain a
+// dollar sign (e.g. a password) can be escaped.
+func expandEnv(s string) string {
+	return os.Expand(s, func(name string) string {
+		if name == "$" {
+			return "$"
+		}
+
+		return os.Getenv(name)
+	})
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,71 @@
+package rockhopper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rockhopper.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfig_ExpandsEnv(t *testing.T) {
+	t.Run("braced form", func(t *testing.T) {
+		t.Setenv("MYSQL8_URL", "root@tcp(localhost:3306)/db?parseTime=true")
+
+		path := writeTempConfig(t, "driver: mysql\ndialect: mysql\ndsn: ${MYSQL8_URL}\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "root@tcp(localhost:3306)/db?parseTime=true", config.DSN)
+		}
+	})
+
+	t.Run("bare form", func(t *testing.T) {
+		t.Setenv("MYSQL8_URL", "user:pass@tcp(db:3306)/app")
+
+		path := writeTempConfig(t, "driver: mysql\ndsn: $MYSQL8_URL\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "user:pass@tcp(db:3306)/app", config.DSN)
+		}
+	})
+
+	t.Run("undefined expands to empty", func(t *testing.T) {
+		os.Unsetenv("ROCKHOPPER_NOPE")
+
+		path := writeTempConfig(t, "driver: mysql\ndsn: ${ROCKHOPPER_NOPE}\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "", config.DSN)
+		}
+	})
+
+	t.Run("dollar escape", func(t *testing.T) {
+		path := writeTempConfig(t, "driver: mysql\ndsn: \"user:p@$$w0rd@tcp(db:3306)/app\"\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "user:p@$w0rd@tcp(db:3306)/app", config.DSN)
+		}
+	})
+
+	t.Run("env var override still wins", func(t *testing.T) {
+		t.Setenv("MYSQL8_URL", "from-file")
+		t.Setenv("ROCKHOPPER_DSN", "from-rockhopper-env")
+
+		path := writeTempConfig(t, "driver: mysql\ndsn: ${MYSQL8_URL}\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			// ROCKHOPPER_DSN (via the env: struct tag) overrides the file value.
+			assert.Equal(t, "from-rockhopper-env", config.DSN)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds environment-variable expansion to the YAML config loader, so connection strings and secrets can be pulled from the environment instead of being committed to the file:

```yaml
driver: mysql
dialect: mysql
dsn: ${MYSQL8_URL}        # expanded from $MYSQL8_URL at load time
migrationsDirs:
- migrations/myapp
```

```sh
export MYSQL8_URL="root:secret@tcp(localhost:3306)/myapp?parseTime=true"
rockhopper up
```

## Behavior

- Both `${VAR}` and bare `$VAR` forms are supported.
- An undefined variable expands to an empty string (same as `os.ExpandEnv`).
- `$$` escapes to a literal `$`, so a value that legitimately contains a dollar sign (e.g. a password) is not mangled. This is why the implementation uses `os.Expand` with a custom mapping rather than plain `os.ExpandEnv` (which would turn `$$` into an empty string).
- Independent of the existing `ROCKHOPPER_*` struct-tag overrides: when both are set, the `ROCKHOPPER_*` env var still wins over the file value.

## Implementation

- `LoadConfig` runs the file contents through `expandEnv()` before `yaml.Unmarshal`.
- `expandEnv` wraps `os.Expand` with a mapping that special-cases `$` → `$`.

## Tests

`TestLoadConfig_ExpandsEnv` covers: braced form, bare form, undefined→empty, the `$$` escape, and `ROCKHOPPER_DSN` precedence over the expanded file value.

`go build ./...` and `go test ./...` both pass.

🤖 Generated with [Claude Code](https://claude.com/code)