### PR TITLE
FEATURE: [mysql_dsn] support MYSQL_UNIX_PORT for Unix socket connections

### DIFF
--- a/mysql_dsn.go
+++ b/mysql_dsn.go
@@ -43,23 +43,44 @@ func buildMySqlDSN() (string, error) {
 		}
 	}
 
-	address := ""
-	if v, ok := os.LookupEnv(prefix + "HOST"); ok {
-		address = v
+	// Separate the credentials from the address with '@', per the go-sql-driver
+	// DSN format user:pass@protocol(address)/dbname. Only add it when some
+	// credentials were provided; otherwise the DSN starts with the protocol.
+	if dsn != "" {
+		dsn += "@"
 	}
 
-	if v, ok := os.LookupEnv(prefix + "PORT"); ok {
-		address += ":" + v
-	}
-
-	if v, ok := os.LookupEnv(prefix + "PROTOCOL"); ok {
-		dsn += v + "(" + address + ")"
+	// MYSQL_UNIX_PORT is the standard MySQL environment variable for the Unix
+	// socket file path. When set, connect over the socket, e.g.:
+	//
+	//   root:pass@unix(/opt/local/var/run/mysql8/mysqld.sock)/test
+	//
+	// It takes precedence over HOST/PORT/PROTOCOL, mirroring how the MySQL
+	// client tools prefer the socket when one is configured.
+	if socket, ok := os.LookupEnv(prefix + "UNIX_PORT"); ok {
+		dsn += "unix(" + socket + ")"
 	} else {
-		dsn += "tcp(" + address + ")"
+		address := ""
+		if v, ok := os.LookupEnv(prefix + "HOST"); ok {
+			address = v
+		}
+
+		if v, ok := os.LookupEnv(prefix + "PORT"); ok {
+			address += ":" + v
+		}
+
+		if v, ok := os.LookupEnv(prefix + "PROTOCOL"); ok {
+			dsn += v + "(" + address + ")"
+		} else {
+			dsn += "tcp(" + address + ")"
+		}
 	}
 
+	// The slash separating the database name is always required by the
+	// go-sql-driver DSN format, even when no database is selected.
+	dsn += "/"
 	if v, ok := os.LookupEnv(prefix + "DATABASE"); ok {
-		dsn += "/" + v
+		dsn += v
 	}
 
 	return dsn, nil

--- a/mysql_dsn_test.go
+++ b/mysql_dsn_test.go
@@ -1,0 +1,90 @@
+package rockhopper
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// clearMySQLEnv removes any MYSQL_ / MYSQL8_ variables from the test process so
+// each case starts from a clean slate.
+func clearMySQLEnv(t *testing.T) {
+	t.Helper()
+	for _, env := range os.Environ() {
+		key := env[:strings.IndexByte(env, '=')]
+		if strings.HasPrefix(key, "MYSQL_") || strings.HasPrefix(key, "MYSQL8_") {
+			t.Setenv(key, "") // ensure t.Setenv records it for restore
+			os.Unsetenv(key)
+		}
+	}
+}
+
+func TestBuildMySqlDSN_UnixSocket(t *testing.T) {
+	clearMySQLEnv(t)
+
+	t.Setenv("MYSQL_USER", "root")
+	t.Setenv("MYSQL_PASSWORD", "123123")
+	t.Setenv("MYSQL_UNIX_PORT", "/opt/local/var/run/mysql8/mysqld.sock")
+	t.Setenv("MYSQL_DATABASE", "test")
+
+	dsn, err := buildMySqlDSN()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "root:123123@unix(/opt/local/var/run/mysql8/mysqld.sock)/test", dsn)
+	}
+}
+
+func TestBuildMySqlDSN_UnixSocketTakesPrecedenceOverHost(t *testing.T) {
+	clearMySQLEnv(t)
+
+	t.Setenv("MYSQL_USER", "root")
+	t.Setenv("MYSQL_HOST", "127.0.0.1")
+	t.Setenv("MYSQL_PORT", "3306")
+	t.Setenv("MYSQL_UNIX_PORT", "/tmp/mysql.sock")
+
+	dsn, err := buildMySqlDSN()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "root@unix(/tmp/mysql.sock)/", dsn)
+	}
+}
+
+func TestBuildMySqlDSN_TCPWhenNoSocket(t *testing.T) {
+	clearMySQLEnv(t)
+
+	t.Setenv("MYSQL_USER", "root")
+	t.Setenv("MYSQL_HOST", "127.0.0.1")
+	t.Setenv("MYSQL_PORT", "3306")
+	t.Setenv("MYSQL_DATABASE", "test")
+
+	dsn, err := buildMySqlDSN()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "root@tcp(127.0.0.1:3306)/test", dsn)
+	}
+}
+
+func TestBuildMySqlDSN_MySQL8PrefixUnixSocket(t *testing.T) {
+	clearMySQLEnv(t)
+
+	// Presence of any MYSQL8_ variable switches the whole lookup to the
+	// MYSQL8_ prefix, including MYSQL8_UNIX_PORT.
+	t.Setenv("MYSQL8_USER", "root")
+	t.Setenv("MYSQL8_UNIX_PORT", "/opt/local/var/run/mysql8/mysqld.sock")
+	t.Setenv("MYSQL8_DATABASE", "test")
+
+	dsn, err := buildMySqlDSN()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "root@unix(/opt/local/var/run/mysql8/mysqld.sock)/test", dsn)
+	}
+}
+
+func TestBuildMySqlDSN_URLPassthrough(t *testing.T) {
+	clearMySQLEnv(t)
+
+	t.Setenv("MYSQL_URL", "root:123123@unix(/opt/local/var/run/mysql8/mysqld.sock)/test")
+
+	dsn, err := buildMySqlDSN()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "root:123123@unix(/opt/local/var/run/mysql8/mysqld.sock)/test", dsn)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for MySQL's standard `MYSQL_UNIX_PORT` environment variable when building a DSN from env vars. Setting it to a Unix socket path produces a socket DSN instead of TCP:

```sh
export MYSQL_USER=root
export MYSQL_PASSWORD=123123
export MYSQL_UNIX_PORT=/opt/local/var/run/mysql8/mysqld.sock
export MYSQL_DATABASE=test
# -> root:123123@unix(/opt/local/var/run/mysql8/mysqld.sock)/test
```

- Takes precedence over `HOST`/`PORT`/`PROTOCOL`, mirroring how the MySQL client tools prefer the socket when one is configured.
- Honors the `MYSQL8_` prefix as well (`MYSQL8_UNIX_PORT`).
- The URL form (`MYSQL_URL=root:123123@unix(/path)/test`) already passed through unchanged.

## Latent DSN bugs fixed along the way

The env-var DSN builder never assembled a valid go-sql-driver DSN once credentials were involved. Both confirmed against `mysql.ParseDSN`:

1. **Missing `@` separator.** Old output `root:123123tcp(...)/test` *parses*, but mis-parses: `user=""`, `pass=""`, `net="root:123123tcp"` — i.e. the username and password are silently dropped and auth breaks. Now a `@` is inserted when credentials are present.
2. **Missing trailing `/`.** When `MYSQL_DATABASE` was unset, the old output had no slash and was outright rejected: `invalid DSN: network address not terminated`. The slash is now always emitted.

These also affect the pre-existing TCP path, so this is a net correctness fix beyond the socket feature.

## Tests

New `mysql_dsn_test.go` covers: socket form, socket precedence over host/port, the `MYSQL8_` prefix, TCP fallback, and `MYSQL_URL` passthrough. The generated DSNs were additionally validated against `go-sql-driver/mysql`'s `ParseDSN` during development.

`go build ./...` and `go test ./...` both pass.

🤖 Generated with [Claude Code](https://claude.com/code)