### PR TITLE
data migration: resumable, checkpointed data-migration API

### DIFF
--- a/datamigration.go
+++ b/datamigration.go
@@ -1,0 +1,212 @@
+package rockhopper
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// DataMigrationTableName is the table that tracks data-migration progress
+// (status + checkpoint). It is intentionally separate from the binary version
+// table (TableName) so the schema runner's done/not-done semantics stay intact.
+const DataMigrationTableName = "rockhopper_data_migrations"
+
+// Data migration status values stored in the status column.
+const (
+	// DataMigrationPending means the migration has a row but no batch has run yet.
+	DataMigrationPending = "pending"
+	// DataMigrationRunning means the migration has started and has a checkpoint.
+	DataMigrationRunning = "running"
+	// DataMigrationCompleted means every batch has been applied.
+	DataMigrationCompleted = "completed"
+	// DataMigrationFailed means a batch returned an error.
+	DataMigrationFailed = "failed"
+)
+
+// Checkpoint is the opaque, serializable progress cursor of a data migration.
+// The framework stores it verbatim and hands it back on resume; only the
+// migrator's own code interprets its contents (commonly JSON).
+type Checkpoint []byte
+
+// Queryer is the read side of a database handle. Data migrations need to read
+// rows to compute batch ranges and detect completion, which the core
+// SQLExecutor (ExecContext only) does not expose. Both *sql.DB and *sql.Tx
+// satisfy Queryer.
+type Queryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// BatchExecutor is handed to DataMigrator.Batch. It is bound to the transaction
+// that also persists the advanced checkpoint, so a batch's writes and its
+// checkpoint commit atomically. *sql.Tx satisfies this interface.
+type BatchExecutor interface {
+	SQLExecutor
+	Queryer
+}
+
+// DataMigrator is implemented by user applications to define a long-running,
+// resumable data migration (e.g. a chunked backfill). The framework owns the
+// loop, checkpoint persistence, throttling and resume; the migrator owns the
+// per-batch logic.
+type DataMigrator interface {
+	// Plan is called once before batching begins, when no checkpoint has been
+	// persisted yet. It may inspect the database (read-only) to compute bounds
+	// such as min/max primary keys, and returns the initial checkpoint. A nil
+	// checkpoint is allowed.
+	Plan(ctx context.Context, q Queryer) (Checkpoint, error)
+
+	// Batch processes a single chunk of work starting from cp and returns the
+	// advanced checkpoint and whether the migration is complete. exec is bound
+	// to the transaction that persists the returned checkpoint, so Batch must
+	// not commit, roll back or sleep. Batches should be idempotent so that an
+	// interrupted batch can safely be retried on resume.
+	Batch(ctx context.Context, exec BatchExecutor, cp Checkpoint) (next Checkpoint, done bool, err error)
+}
+
+// DataMigration is the registered descriptor for a data migration. It carries
+// the migrator together with scheduling metadata (dependency, throttle).
+type DataMigration struct {
+	// Package is the migration package name.
+	Package string
+
+	// Version is the data-migration version (parsed from the source filename).
+	Version int64
+
+	// Name is a human-readable description.
+	Name string
+
+	// Source is the path to the file that registered the migration.
+	Source string
+
+	// Migrator holds the user-provided batch logic.
+	Migrator DataMigrator
+
+	// After is the schema migration version (same package) that must be applied
+	// before this data migration becomes eligible to run. Zero means no
+	// dependency.
+	After int64
+
+	// Throttle is the pause inserted between batches to limit load and
+	// replication lag. Zero means no pause.
+	Throttle time.Duration
+}
+
+func (dm *DataMigration) String() string {
+	if dm.Name != "" {
+		return fmt.Sprintf("%s:%d (%s)", dm.Package, dm.Version, dm.Name)
+	}
+
+	return fmt.Sprintf("%s:%d", dm.Package, dm.Version)
+}
+
+// DataMigrationOption customizes a registered DataMigration.
+type DataMigrationOption func(*DataMigration)
+
+// After declares that the data migration may only run once the given schema
+// migration version (in the same package) has been applied.
+func After(schemaVersion int64) DataMigrationOption {
+	return func(dm *DataMigration) {
+		dm.After = schemaVersion
+	}
+}
+
+// WithThrottle sets the pause inserted between batches.
+func WithThrottle(d time.Duration) DataMigrationOption {
+	return func(dm *DataMigration) {
+		dm.Throttle = d
+	}
+}
+
+// WithDataMigrationName sets a human-readable description.
+func WithDataMigrationName(name string) DataMigrationOption {
+	return func(dm *DataMigration) {
+		dm.Name = name
+	}
+}
+
+// registeredDataMigrations stores the globally registered data migrations,
+// keyed the same way as registeredGoMigrations.
+var registeredDataMigrations = map[RegistryKey]*DataMigration{}
+
+// AddDataMigration registers a data migration into the global map. The version
+// is parsed from the caller's source filename and the package is derived from
+// the caller's function name, mirroring AddMigration.
+func AddDataMigration(m DataMigrator, opts ...DataMigrationOption) {
+	pc, filename, _, _ := runtime.Caller(1)
+
+	funcName := runtime.FuncForPC(pc).Name()
+	lastSlash := strings.LastIndexByte(funcName, '/')
+	if lastSlash < 0 {
+		lastSlash = 0
+	}
+
+	lastDot := strings.LastIndexByte(funcName[lastSlash:], '.') + lastSlash
+	packageName := funcName[:lastDot]
+	AddNamedDataMigration(packageName, filename, m, opts...)
+}
+
+// AddNamedDataMigration registers a data migration with an explicit package and
+// source filename. The version is parsed from the filename.
+func AddNamedDataMigration(packageName, filename string, m DataMigrator, opts ...DataMigrationOption) {
+	v, err := FileNumericComponent(filename)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	dm := &DataMigration{
+		Package:  packageName,
+		Version:  v,
+		Source:   filename,
+		Migrator: m,
+	}
+
+	for _, opt := range opts {
+		opt(dm)
+	}
+
+	key := RegistryKey{Package: packageName, Version: v}
+	if existing, ok := registeredDataMigrations[key]; ok {
+		panic(fmt.Sprintf("failed to add data migration %q: version conflicts with %q", filename, existing.Source))
+	}
+
+	registeredDataMigrations[key] = dm
+}
+
+// DataMigrations returns all the registered data migrations sorted by version.
+func DataMigrations() []*DataMigration {
+	var all []*DataMigration
+	for _, dm := range registeredDataMigrations {
+		all = append(all, dm)
+	}
+
+	sortDataMigrations(all)
+	return all
+}
+
+// DataMigrationsByPackage returns the registered data migrations for the given
+// package, sorted by version.
+func DataMigrationsByPackage(packageName string) []*DataMigration {
+	var all []*DataMigration
+	for _, dm := range registeredDataMigrations {
+		if dm.Package == packageName {
+			all = append(all, dm)
+		}
+	}
+
+	sortDataMigrations(all)
+	return all
+}
+
+func sortDataMigrations(s []*DataMigration) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1].Version > s[j].Version; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/datamigration_run.go
+++ b/datamigration_run.go
@@ -1,0 +1,224 @@
+package rockhopper
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// TouchDataMigrationTable creates the data-migration state table if it does not
+// exist yet.
+func (db *DB) TouchDataMigrationTable(ctx context.Context) error {
+	if _, err := db.ExecContext(ctx, db.dialect.CreateDataMigrationTableSQL(DataMigrationTableName)); err != nil {
+		return errors.Wrap(err, "failed to create data migration table")
+	}
+
+	return nil
+}
+
+// loadDataMigrationState loads the persisted status and checkpoint for a data
+// migration. found is false when no row exists yet.
+func (db *DB) loadDataMigrationState(ctx context.Context, pkgName string, version int64) (status string, cp Checkpoint, found bool, err error) {
+	row := db.QueryRowContext(ctx, db.dialect.SelectDataMigrationSQL(DataMigrationTableName), pkgName, version)
+
+	var checkpoint sql.NullString
+	if err := row.Scan(&status, &checkpoint); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil, false, nil
+		}
+
+		return "", nil, false, errors.Wrap(err, "failed to load data migration state")
+	}
+
+	if checkpoint.Valid && checkpoint.String != "" {
+		cp = Checkpoint(checkpoint.String)
+	}
+
+	return status, cp, true, nil
+}
+
+// insertDataMigrationState inserts the initial state row for a data migration.
+func (db *DB) insertDataMigrationState(ctx context.Context, exec SQLExecutor, dm *DataMigration, status string, cp Checkpoint) error {
+	if _, err := exec.ExecContext(ctx,
+		db.dialect.InsertDataMigrationSQL(DataMigrationTableName),
+		dm.Package, dm.Version, dm.Name, status, string(cp)); err != nil {
+		return errors.Wrap(err, "failed to insert data migration state")
+	}
+
+	return nil
+}
+
+// updateDataMigrationState updates the status and checkpoint of a data
+// migration. It accepts an executor so the update can run inside the same
+// transaction as the batch it records.
+func (db *DB) updateDataMigrationState(ctx context.Context, exec SQLExecutor, dm *DataMigration, status string, cp Checkpoint) error {
+	if _, err := exec.ExecContext(ctx,
+		db.dialect.UpdateDataMigrationSQL(DataMigrationTableName),
+		status, string(cp), dm.Package, dm.Version); err != nil {
+		return errors.Wrap(err, "failed to update data migration state")
+	}
+
+	return nil
+}
+
+// isSchemaVersionApplied reports whether the given schema version of a package
+// has been applied in the version table.
+func (db *DB) isSchemaVersionApplied(ctx context.Context, pkgName string, version int64) (bool, error) {
+	m, err := db.LoadMigration(ctx, &Migration{Package: pkgName, Version: version})
+	if err != nil {
+		return false, err
+	}
+
+	return m != nil && m.Record != nil && m.Record.IsApplied, nil
+}
+
+// RunDataMigration drives a single data migration to completion. It is safe to
+// call repeatedly: a completed migration is skipped, and an interrupted one
+// resumes from its last persisted checkpoint.
+//
+// Each batch and its checkpoint advance are committed together in one
+// transaction, so a process that dies mid-batch rolls back cleanly and resumes
+// without double-applying committed work.
+func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
+	if dm.Migrator == nil {
+		return fmt.Errorf("data migration %s has no migrator", dm)
+	}
+
+	// ensure both the version table (for the dependency check) and the
+	// data-migration state table exist.
+	if err := db.Touch(ctx); err != nil {
+		return err
+	}
+
+	if err := db.TouchDataMigrationTable(ctx); err != nil {
+		return err
+	}
+
+	// dependency gate: the mapped schema migration must be applied first.
+	if dm.After > 0 {
+		applied, err := db.isSchemaVersionApplied(ctx, dm.Package, dm.After)
+		if err != nil {
+			return err
+		}
+
+		if !applied {
+			return fmt.Errorf("data migration %s depends on schema version %d which is not applied yet", dm, dm.After)
+		}
+	}
+
+	status, cp, found, err := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
+	if err != nil {
+		return err
+	}
+
+	if found && status == DataMigrationCompleted {
+		log.Infof("data migration %s already completed, skipping", dm)
+		return nil
+	}
+
+	if !found {
+		// first run: compute the starting checkpoint and persist the initial row.
+		cp, err = dm.Migrator.Plan(ctx, db.DB)
+		if err != nil {
+			return errors.Wrapf(err, "data migration %s: plan failed", dm)
+		}
+
+		if err := db.insertDataMigrationState(ctx, db.DB, dm, DataMigrationRunning, cp); err != nil {
+			return err
+		}
+	} else {
+		log.Infof("resuming data migration %s from checkpoint", dm)
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		next, done, err := db.runDataBatch(ctx, dm, cp)
+		if err != nil {
+			// best-effort mark as failed in a separate transaction.
+			if uerr := db.updateDataMigrationState(ctx, db.DB, dm, DataMigrationFailed, cp); uerr != nil {
+				log.WithError(uerr).Warnf("failed to mark data migration %s as failed", dm)
+			}
+
+			return errors.Wrapf(err, "data migration %s: batch failed", dm)
+		}
+
+		cp = next
+
+		if done {
+			log.Infof("data migration %s completed", dm)
+			return nil
+		}
+
+		if dm.Throttle > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(dm.Throttle):
+			}
+		}
+	}
+}
+
+// runDataBatch runs one batch and persists its checkpoint in a single
+// transaction.
+func (db *DB) runDataBatch(ctx context.Context, dm *DataMigration, cp Checkpoint) (next Checkpoint, done bool, err error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, false, err
+	}
+
+	next, done, err = dm.Migrator.Batch(ctx, tx, cp)
+	if err != nil {
+		return nil, false, rollbackAndLogErr(err, tx, "data migration batch failed")
+	}
+
+	status := DataMigrationRunning
+	if done {
+		status = DataMigrationCompleted
+	}
+
+	if err := db.updateDataMigrationState(ctx, tx, dm, status, next); err != nil {
+		return nil, false, rollbackAndLogErr(err, tx, "failed to persist data migration checkpoint")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, false, errors.Wrap(err, "failed to commit data migration batch")
+	}
+
+	return next, done, nil
+}
+
+// RunDataMigrations runs the given data migrations in version order.
+func RunDataMigrations(ctx context.Context, db *DB, dms []*DataMigration) error {
+	for _, dm := range dms {
+		if err := RunDataMigration(ctx, db, dm); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RunRegisteredDataMigrations runs all the registered data migrations for the
+// given packages (or every package when none is given), in version order.
+func RunRegisteredDataMigrations(ctx context.Context, db *DB, packages ...string) error {
+	var dms []*DataMigration
+	if len(packages) == 0 {
+		dms = DataMigrations()
+	} else {
+		for _, pkg := range packages {
+			dms = append(dms, DataMigrationsByPackage(pkg)...)
+		}
+
+		sortDataMigrations(dms)
+	}
+
+	return RunDataMigrations(ctx, db, dms)
+}

--- a/datamigration_test.go
+++ b/datamigration_test.go
@@ -1,0 +1,217 @@
+package rockhopper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pkCursor is the JSON-serialized checkpoint used by the test backfill: it
+// advances an exclusive lower bound over an auto-increment primary key.
+type pkCursor struct {
+	Last int64 `json:"last"`
+	Max  int64 `json:"max"`
+}
+
+// backfillMigrator marks every row in a table as migrated, batch.size rows at a
+// time. failAfterBatch lets a test simulate a crash mid-migration.
+type backfillMigrator struct {
+	table          string
+	batchSize      int64
+	failAfterBatch int
+
+	planCalls  int
+	batchCalls int
+}
+
+func (b *backfillMigrator) Plan(ctx context.Context, q Queryer) (Checkpoint, error) {
+	b.planCalls++
+
+	var c pkCursor
+	if err := q.QueryRowContext(ctx, "SELECT COALESCE(MAX(id), 0) FROM "+b.table).Scan(&c.Max); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(c)
+}
+
+func (b *backfillMigrator) Batch(ctx context.Context, exec BatchExecutor, cp Checkpoint) (Checkpoint, bool, error) {
+	b.batchCalls++
+	if b.failAfterBatch > 0 && b.batchCalls > b.failAfterBatch {
+		return nil, false, fmt.Errorf("simulated crash at batch %d", b.batchCalls)
+	}
+
+	var c pkCursor
+	if err := json.Unmarshal(cp, &c); err != nil {
+		return nil, false, err
+	}
+
+	hi := c.Last + b.batchSize
+	// idempotent: only touches rows in the (Last, hi] window that are not yet migrated.
+	if _, err := exec.ExecContext(ctx,
+		"UPDATE "+b.table+" SET migrated = 1 WHERE id > ? AND id <= ? AND migrated = 0", c.Last, hi); err != nil {
+		return nil, false, err
+	}
+
+	c.Last = hi
+	next, err := json.Marshal(c)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return next, c.Last >= c.Max, nil
+}
+
+func openDataMigrationTestDB(t *testing.T) *DB {
+	t.Helper()
+
+	d, err := LoadDialect("sqlite3")
+	require.NoError(t, err)
+
+	db, err := Open("sqlite3", d, ":memory:", TableName)
+	require.NoError(t, err)
+
+	// :memory: gives a fresh database per connection; pin the pool to one
+	// connection so all statements see the same database.
+	db.SetMaxOpenConns(1)
+
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, migrated INTEGER NOT NULL DEFAULT 0)`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func seedUsers(t *testing.T, db *DB, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		_, err := db.Exec(`INSERT INTO users (migrated) VALUES (0)`)
+		require.NoError(t, err)
+	}
+}
+
+func countMigrated(t *testing.T, db *DB) int {
+	t.Helper()
+	var c int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM users WHERE migrated = 1`).Scan(&c))
+	return c
+}
+
+func TestRunDataMigration_Backfill(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000001, Name: "backfill_users", Migrator: mig}
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+
+	assert.Equal(t, 25, countMigrated(t, db))
+	assert.Equal(t, 1, mig.planCalls)
+	assert.Equal(t, 3, mig.batchCalls) // 10 + 10 + 5
+
+	status, _, found, err := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, DataMigrationCompleted, status)
+}
+
+func TestRunDataMigration_SkipsWhenCompleted(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 5)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000002, Migrator: mig}
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+
+	// the second run must not call Plan or Batch again.
+	assert.Equal(t, 1, mig.planCalls)
+	assert.Equal(t, 1, mig.batchCalls)
+}
+
+func TestRunDataMigration_ResumesAfterFailure(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	// fail after the second committed batch (20 rows migrated, checkpoint at 20).
+	mig := &backfillMigrator{table: "users", batchSize: 10, failAfterBatch: 2}
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000003, Migrator: mig}
+
+	err := RunDataMigration(ctx, db, dm)
+	require.Error(t, err)
+
+	status, _, found, err := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, DataMigrationFailed, status)
+	assert.Equal(t, 20, countMigrated(t, db)) // two batches committed before the crash
+
+	// resume: stop failing and run again.
+	mig.failAfterBatch = 0
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+
+	assert.Equal(t, 25, countMigrated(t, db))
+	// Plan must not be called again on resume.
+	assert.Equal(t, 1, mig.planCalls)
+
+	status, _, _, err = db.loadDataMigrationState(ctx, dm.Package, dm.Version)
+	require.NoError(t, err)
+	assert.Equal(t, DataMigrationCompleted, status)
+}
+
+func TestAddNamedDataMigration(t *testing.T) {
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	AddNamedDataMigration("backfillpkg", "1700000000000010_backfill_users.go", mig,
+		After(1699999999999999),
+		WithThrottle(0),
+		WithDataMigrationName("backfill users"),
+	)
+
+	got := DataMigrationsByPackage("backfillpkg")
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(1700000000000010), got[0].Version)
+	assert.Equal(t, int64(1699999999999999), got[0].After)
+	assert.Equal(t, "backfill users", got[0].Name)
+	assert.Same(t, mig, got[0].Migrator.(*backfillMigrator))
+}
+
+func TestRunDataMigration_DependencyGate(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 5)
+	require.NoError(t, db.Touch(ctx))
+
+	const schemaVersion = int64(1699999999999999)
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{
+		Package:  DefaultPackageName,
+		Version:  1700000000000004,
+		Migrator: mig,
+		After:    schemaVersion,
+	}
+
+	// schema dependency not applied yet -> refuse to run.
+	err := RunDataMigration(ctx, db, dm)
+	require.Error(t, err)
+	assert.Equal(t, 0, countMigrated(t, db))
+
+	// apply the schema version, then it should run.
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	require.NoError(t, db.insertVersion(ctx, tx, DefaultPackageName, "", schemaVersion, true))
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 5, countMigrated(t, db))
+}

--- a/dialect.go
+++ b/dialect.go
@@ -32,6 +32,24 @@ type SQLDialect interface {
 	// QueryVersionsSQL returns the sql string to query the version info descending
 	QueryVersionsSQL(tableName string) string
 	DBVersionQuery(db *sql.DB, tableName string) (*sql.Rows, error)
+
+	// CreateDataMigrationTableSQL returns the sql string to create the
+	// data-migration state table (checkpoint/status tracking).
+	CreateDataMigrationTableSQL(tableName string) string
+
+	// InsertDataMigrationSQL returns the sql string to insert a new
+	// data-migration state row. Argument order: package, version_id, name,
+	// status, checkpoint.
+	InsertDataMigrationSQL(tableName string) string
+
+	// UpdateDataMigrationSQL returns the sql string to update an existing
+	// data-migration state row. Argument order: status, checkpoint, package,
+	// version_id.
+	UpdateDataMigrationSQL(tableName string) string
+
+	// SelectDataMigrationSQL returns the sql string to load the status and
+	// checkpoint of a data migration. Argument order: package, version_id.
+	SelectDataMigrationSQL(tableName string) string
 }
 
 func LoadDialect(d string) (SQLDialect, error) {

--- a/pkg/dialect/mysql.go
+++ b/pkg/dialect/mysql.go
@@ -53,3 +53,30 @@ func (m MySQLDialect) MigrationSQL(tableName string) string {
 func (m MySQLDialect) DeleteVersionSQL(tableName string) string {
 	return fmt.Sprintf("DELETE FROM %s WHERE package = ? AND version_id = ?", tableName)
 }
+
+func (m MySQLDialect) CreateDataMigrationTableSQL(tableName string) string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+                id SERIAL NOT NULL,
+                package VARCHAR(125) NOT NULL DEFAULT 'main',
+                version_id BIGINT NOT NULL,
+                name VARCHAR(255) NOT NULL DEFAULT '',
+                status VARCHAR(32) NOT NULL DEFAULT 'pending',
+                checkpoint TEXT,
+                created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                PRIMARY KEY(id),
+                UNIQUE KEY uniq_data_migration (package, version_id)
+            );`, tableName)
+}
+
+func (m MySQLDialect) InsertDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES (?, ?, ?, ?, ?)", tableName)
+}
+
+func (m MySQLDialect) UpdateDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, updated_at = NOW() WHERE package = ? AND version_id = ?", tableName)
+}
+
+func (m MySQLDialect) SelectDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = ? AND version_id = ?", tableName)
+}

--- a/pkg/dialect/pgsql.go
+++ b/pkg/dialect/pgsql.go
@@ -53,3 +53,30 @@ func (d PostgresDialect) MigrationSQL(tableName string) string {
 func (d PostgresDialect) DeleteVersionSQL(tableName string) string {
 	return fmt.Sprintf("DELETE FROM %s WHERE package = $1 AND version_id = $2", tableName)
 }
+
+func (d PostgresDialect) CreateDataMigrationTableSQL(tableName string) string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+                id serial NOT NULL,
+                package VARCHAR(128) NOT NULL DEFAULT 'main',
+                version_id BIGINT NOT NULL,
+                name VARCHAR(255) NOT NULL DEFAULT '',
+                status VARCHAR(32) NOT NULL DEFAULT 'pending',
+                checkpoint TEXT,
+                created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                PRIMARY KEY(id),
+                UNIQUE(package, version_id)
+            );`, tableName)
+}
+
+func (d PostgresDialect) InsertDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES ($1, $2, $3, $4, $5)", tableName)
+}
+
+func (d PostgresDialect) UpdateDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = $1, checkpoint = $2, updated_at = NOW() WHERE package = $3 AND version_id = $4", tableName)
+}
+
+func (d PostgresDialect) SelectDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = $1 AND version_id = $2", tableName)
+}

--- a/pkg/dialect/redshift.go
+++ b/pkg/dialect/redshift.go
@@ -52,3 +52,29 @@ func (d RedshiftDialect) MigrationSQL(tableName string) string {
 func (d RedshiftDialect) DeleteVersionSQL(tableName string) string {
 	return fmt.Sprintf("DELETE FROM %s WHERE package = $1 AND version_id = $2", tableName)
 }
+
+func (d RedshiftDialect) CreateDataMigrationTableSQL(tableName string) string {
+	return fmt.Sprintf(`CREATE TABLE %s (
+                id INTEGER NOT NULL identity(1, 1),
+                package VARCHAR(128) NOT NULL DEFAULT 'main',
+                version_id BIGINT NOT NULL,
+                name VARCHAR(255) NOT NULL DEFAULT '',
+                status VARCHAR(32) NOT NULL DEFAULT 'pending',
+                checkpoint VARCHAR(65535),
+                created_at TIMESTAMP NULL default sysdate,
+                updated_at TIMESTAMP NULL default sysdate,
+                PRIMARY KEY(id)
+            );`, tableName)
+}
+
+func (d RedshiftDialect) InsertDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES ($1, $2, $3, $4, $5)", tableName)
+}
+
+func (d RedshiftDialect) UpdateDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = $1, checkpoint = $2, updated_at = sysdate WHERE package = $3 AND version_id = $4", tableName)
+}
+
+func (d RedshiftDialect) SelectDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = $1 AND version_id = $2", tableName)
+}

--- a/pkg/dialect/sqlite3.go
+++ b/pkg/dialect/sqlite3.go
@@ -51,3 +51,29 @@ func (m Sqlite3Dialect) MigrationSQL(tableName string) string {
 func (m Sqlite3Dialect) DeleteVersionSQL(tableName string) string {
 	return fmt.Sprintf("DELETE FROM %s WHERE package = ? AND version_id = ?", tableName)
 }
+
+func (m Sqlite3Dialect) CreateDataMigrationTableSQL(tableName string) string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                package TEXT NOT NULL DEFAULT 'main',
+                version_id INTEGER NOT NULL,
+                name TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'pending',
+                checkpoint TEXT,
+                created_at TIMESTAMP DEFAULT (datetime('now')),
+                updated_at TIMESTAMP DEFAULT (datetime('now')),
+                UNIQUE(package, version_id)
+            );`, tableName)
+}
+
+func (m Sqlite3Dialect) InsertDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES (?, ?, ?, ?, ?)", tableName)
+}
+
+func (m Sqlite3Dialect) UpdateDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, updated_at = datetime('now') WHERE package = ? AND version_id = ?", tableName)
+}
+
+func (m Sqlite3Dialect) SelectDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = ? AND version_id = ?", tableName)
+}

--- a/pkg/dialect/tidb.go
+++ b/pkg/dialect/tidb.go
@@ -52,3 +52,30 @@ func (m TiDBDialect) MigrationSQL(tableName string) string {
 func (m TiDBDialect) DeleteVersionSQL(tableName string) string {
 	return fmt.Sprintf("DELETE FROM %s WHERE package = ? AND version_id = ?", tableName)
 }
+
+func (m TiDBDialect) CreateDataMigrationTableSQL(tableName string) string {
+	return fmt.Sprintf(`CREATE TABLE %s (
+                id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE,
+                package VARCHAR(128) NOT NULL DEFAULT 'main',
+                version_id BIGINT NOT NULL,
+                name VARCHAR(255) NOT NULL DEFAULT '',
+                status VARCHAR(32) NOT NULL DEFAULT 'pending',
+                checkpoint TEXT,
+                created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                PRIMARY KEY(id),
+                UNIQUE KEY uniq_data_migration (package, version_id)
+            );`, tableName)
+}
+
+func (m TiDBDialect) InsertDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES (?, ?, ?, ?, ?)", tableName)
+}
+
+func (m TiDBDialect) UpdateDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, updated_at = NOW() WHERE package = ? AND version_id = ?", tableName)
+}
+
+func (m TiDBDialect) SelectDataMigrationSQL(tableName string) string {
+	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = ? AND version_id = ?", tableName)
+}


### PR DESCRIPTION
## Summary

Adds a long-running, resumable **data-migration** runner alongside the existing binary schema-migration runner. This is the first step toward gh-ost-style progressive migrations, scoped to **data backfills** (dialect-agnostic, no online-DDL cut-over) rather than online schema change.

Schema migrations keep their done/not-done semantics in `rockhopper_versions`. Data migrations track **status + checkpoint** in a new `rockhopper_data_migrations` table, so a chunked backfill can run for hours, survive process restarts, and resume from where it left off.

## API

```go
type DataMigrator interface {
    Plan(ctx context.Context, q Queryer) (Checkpoint, error)
    Batch(ctx context.Context, exec BatchExecutor, cp Checkpoint) (next Checkpoint, done bool, err error)
}

rockhopper.AddDataMigration(&BackfillPnL{...},
    rockhopper.After(1749990000),            // run only after this schema version is applied
    rockhopper.WithThrottle(200*time.Millisecond),
)
```

- The user writes the **cursor + per-batch work**; the framework owns the **loop, checkpoint persistence, throttle, resume, and dependency gating**.
- `Queryer` adds the read side the core `SQLExecutor` lacked; `BatchExecutor = SQLExecutor + Queryer` (satisfied by `*sql.Tx`).
- Registration mirrors `AddMigration` (version from filename, package from caller).

## Correctness

Each **batch and its checkpoint advance commit in one transaction**, so a process killed mid-batch rolls back cleanly and resumes without re-applying committed work (exactly-once per batch). Batches are expected to be idempotent for the rollback-and-retry case.

## Dialects

`SQLDialect` gains `Create/Insert/Update/Select` data-migration SQL, implemented for **mysql, tidb, sqlite3, postgres, redshift**. Uses portable insert-once-then-update (no `ON CONFLICT`/upsert) so Redshift works too.

## Tests

Backfill completion, skip-when-completed, resume-after-failure (verifies committed-only progress + no re-`Plan`), dependency gate, and registration.

## Follow-ups (not in this PR)

- **Lease / single-driver column** for true multi-pod safety (currently relies on a single driver, e.g. k8s `Job` with `parallelism: 1`) — starting next.
- Reverse dependency (a *contract* schema migration waiting on a data migration's completion).
- CLI integration and data-migration down/rollback semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)