### PR TITLE
data migration: DB lease for single-driver multi-pod safety

### DIFF
--- a/datamigration.go
+++ b/datamigration.go
@@ -2,12 +2,17 @@ package rockhopper
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -27,6 +32,50 @@ const (
 	// DataMigrationFailed means a batch returned an error.
 	DataMigrationFailed = "failed"
 )
+
+// DefaultLeaseTTL is the lease duration used when a data migration does not set
+// one. The lease is renewed on every batch commit, so the TTL only needs to
+// comfortably exceed a single batch's duration plus its throttle pause.
+const DefaultLeaseTTL = 30 * time.Second
+
+var (
+	// ErrLeaseHeld is returned when another live process holds the lease for a
+	// data migration. Callers running a single driver (e.g. a Kubernetes Job
+	// with parallelism 1) may treat this as a benign "someone else is on it".
+	ErrLeaseHeld = errors.New("data migration lease is held by another process")
+
+	// ErrLeaseLost is returned when the lease was taken over by another process
+	// mid-run (the holder stalled past the TTL). The in-flight batch is rolled
+	// back rather than committed.
+	ErrLeaseLost = errors.New("data migration lease lost to another process")
+)
+
+// leaseOwner identifies this process when claiming leases. It is computed once
+// and is unique per process (and per pod, since the hostname is the pod name in
+// Kubernetes).
+var (
+	leaseOwnerOnce  sync.Once
+	leaseOwnerValue string
+)
+
+func leaseOwner() string {
+	leaseOwnerOnce.Do(func() {
+		host, err := os.Hostname()
+		if err != nil || host == "" {
+			host = "unknown"
+		}
+
+		var nonce [4]byte
+		if _, err := rand.Read(nonce[:]); err != nil {
+			leaseOwnerValue = fmt.Sprintf("%s:%d", host, os.Getpid())
+			return
+		}
+
+		leaseOwnerValue = fmt.Sprintf("%s:%d:%s", host, os.Getpid(), hex.EncodeToString(nonce[:]))
+	})
+
+	return leaseOwnerValue
+}
 
 // Checkpoint is the opaque, serializable progress cursor of a data migration.
 // The framework stores it verbatim and hands it back on resume; only the
@@ -95,6 +144,19 @@ type DataMigration struct {
 	// Throttle is the pause inserted between batches to limit load and
 	// replication lag. Zero means no pause.
 	Throttle time.Duration
+
+	// LeaseTTL is how long an acquired lease stays valid before another process
+	// may steal it. It is renewed on every batch commit. Zero means
+	// DefaultLeaseTTL. It must exceed a single batch's duration plus Throttle.
+	LeaseTTL time.Duration
+}
+
+func (dm *DataMigration) leaseTTL() time.Duration {
+	if dm.LeaseTTL > 0 {
+		return dm.LeaseTTL
+	}
+
+	return DefaultLeaseTTL
 }
 
 func (dm *DataMigration) String() string {
@@ -127,6 +189,15 @@ func WithThrottle(d time.Duration) DataMigrationOption {
 func WithDataMigrationName(name string) DataMigrationOption {
 	return func(dm *DataMigration) {
 		dm.Name = name
+	}
+}
+
+// WithLeaseTTL sets how long an acquired lease stays valid before another
+// process may steal it. It must exceed a single batch's duration plus the
+// throttle pause.
+func WithLeaseTTL(d time.Duration) DataMigrationOption {
+	return func(dm *DataMigration) {
+		dm.LeaseTTL = d
 	}
 }
 

--- a/datamigration_run.go
+++ b/datamigration_run.go
@@ -52,14 +52,35 @@ func (db *DB) insertDataMigrationState(ctx context.Context, exec SQLExecutor, dm
 	return nil
 }
 
-// updateDataMigrationState updates the status and checkpoint of a data
-// migration. It accepts an executor so the update can run inside the same
-// transaction as the batch it records.
-func (db *DB) updateDataMigrationState(ctx context.Context, exec SQLExecutor, dm *DataMigration, status string, cp Checkpoint) error {
-	if _, err := exec.ExecContext(ctx,
-		db.dialect.UpdateDataMigrationSQL(DataMigrationTableName),
-		status, string(cp), dm.Package, dm.Version); err != nil {
-		return errors.Wrap(err, "failed to update data migration state")
+// acquireDataMigrationLease attempts to claim the lease for a data migration.
+// It succeeds when the lease is unowned, already owned by this process, or
+// expired. It returns false (without error) when another live process holds it.
+func (db *DB) acquireDataMigrationLease(ctx context.Context, dm *DataMigration, owner string, ttl time.Duration) (bool, error) {
+	now := time.Now()
+	expiresAt := now.Add(ttl).Unix()
+
+	res, err := db.ExecContext(ctx,
+		db.dialect.AcquireDataMigrationLeaseSQL(DataMigrationTableName),
+		owner, expiresAt, dm.Package, dm.Version, owner, now.Unix())
+	if err != nil {
+		return false, errors.Wrap(err, "failed to acquire data migration lease")
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to read affected rows for lease acquisition")
+	}
+
+	return affected == 1, nil
+}
+
+// releaseDataMigrationLease sets a terminal status and clears the lease, guarded
+// by ownership (a process that no longer holds the lease is a no-op).
+func (db *DB) releaseDataMigrationLease(ctx context.Context, dm *DataMigration, owner, status string) error {
+	if _, err := db.ExecContext(ctx,
+		db.dialect.ReleaseDataMigrationLeaseSQL(DataMigrationTableName),
+		status, dm.Package, dm.Version, owner); err != nil {
+		return errors.Wrap(err, "failed to release data migration lease")
 	}
 
 	return nil
@@ -80,9 +101,14 @@ func (db *DB) isSchemaVersionApplied(ctx context.Context, pkgName string, versio
 // call repeatedly: a completed migration is skipped, and an interrupted one
 // resumes from its last persisted checkpoint.
 //
-// Each batch and its checkpoint advance are committed together in one
-// transaction, so a process that dies mid-batch rolls back cleanly and resumes
-// without double-applying committed work.
+// Exactly one process drives a migration at a time, enforced by a lease in the
+// state table. If another live process already holds the lease, ErrLeaseHeld is
+// returned; if the lease is stolen mid-run (this process stalled past the TTL),
+// ErrLeaseLost is returned and the in-flight batch is rolled back.
+//
+// Each batch, its checkpoint advance and the lease renewal commit together in
+// one transaction, so a process that dies mid-batch rolls back cleanly and
+// resumes without double-applying committed work.
 func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 	if dm.Migrator == nil {
 		return fmt.Errorf("data migration %s has no migrator", dm)
@@ -110,7 +136,7 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 		}
 	}
 
-	status, cp, found, err := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
+	status, _, found, err := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
 	if err != nil {
 		return err
 	}
@@ -120,15 +146,60 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 		return nil
 	}
 
+	// make sure a row exists so the lease can be claimed.
 	if !found {
-		// first run: compute the starting checkpoint and persist the initial row.
+		if err := db.insertDataMigrationState(ctx, db.DB, dm, DataMigrationPending, nil); err != nil {
+			// another process may have inserted concurrently; re-check.
+			status, _, found, lerr := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
+			if lerr != nil {
+				return lerr
+			}
+
+			if !found {
+				return err
+			}
+
+			if status == DataMigrationCompleted {
+				log.Infof("data migration %s already completed, skipping", dm)
+				return nil
+			}
+		}
+	}
+
+	owner := leaseOwner()
+	ttl := dm.leaseTTL()
+
+	acquired, err := db.acquireDataMigrationLease(ctx, dm, owner, ttl)
+	if err != nil {
+		return err
+	}
+
+	if !acquired {
+		log.Infof("data migration %s is driven by another process, skipping", dm)
+		return ErrLeaseHeld
+	}
+
+	// we hold the lease; reload the authoritative status and checkpoint (a
+	// stolen lease resumes from the previous owner's last committed batch).
+	status, cp, _, err := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
+	if err != nil {
+		return err
+	}
+
+	if status == DataMigrationCompleted {
+		log.Infof("data migration %s already completed, skipping", dm)
+		return db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationCompleted)
+	}
+
+	if status == DataMigrationPending {
+		// first run: compute the starting checkpoint.
 		cp, err = dm.Migrator.Plan(ctx, db.DB)
 		if err != nil {
-			return errors.Wrapf(err, "data migration %s: plan failed", dm)
-		}
+			if rerr := db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationFailed); rerr != nil {
+				log.WithError(rerr).Warnf("failed to release lease for data migration %s after plan error", dm)
+			}
 
-		if err := db.insertDataMigrationState(ctx, db.DB, dm, DataMigrationRunning, cp); err != nil {
-			return err
+			return errors.Wrapf(err, "data migration %s: plan failed", dm)
 		}
 	} else {
 		log.Infof("resuming data migration %s from checkpoint", dm)
@@ -139,11 +210,15 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 			return err
 		}
 
-		next, done, err := db.runDataBatch(ctx, dm, cp)
+		next, done, err := db.runDataBatch(ctx, dm, owner, ttl, cp)
 		if err != nil {
-			// best-effort mark as failed in a separate transaction.
-			if uerr := db.updateDataMigrationState(ctx, db.DB, dm, DataMigrationFailed, cp); uerr != nil {
-				log.WithError(uerr).Warnf("failed to mark data migration %s as failed", dm)
+			if errors.Is(err, ErrLeaseLost) {
+				// another process owns the migration now; leave its state alone.
+				return err
+			}
+
+			if rerr := db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationFailed); rerr != nil {
+				log.WithError(rerr).Warnf("failed to mark data migration %s as failed", dm)
 			}
 
 			return errors.Wrapf(err, "data migration %s: batch failed", dm)
@@ -153,7 +228,7 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 
 		if done {
 			log.Infof("data migration %s completed", dm)
-			return nil
+			return db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationCompleted)
 		}
 
 		if dm.Throttle > 0 {
@@ -166,9 +241,10 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 	}
 }
 
-// runDataBatch runs one batch and persists its checkpoint in a single
-// transaction.
-func (db *DB) runDataBatch(ctx context.Context, dm *DataMigration, cp Checkpoint) (next Checkpoint, done bool, err error) {
+// runDataBatch runs one batch and persists its checkpoint while renewing the
+// lease, all in a single transaction. It returns ErrLeaseLost if ownership was
+// taken over before the batch could commit.
+func (db *DB) runDataBatch(ctx context.Context, dm *DataMigration, owner string, ttl time.Duration, cp Checkpoint) (next Checkpoint, done bool, err error) {
 	tx, err := db.Begin()
 	if err != nil {
 		return nil, false, err
@@ -184,8 +260,23 @@ func (db *DB) runDataBatch(ctx context.Context, dm *DataMigration, cp Checkpoint
 		status = DataMigrationCompleted
 	}
 
-	if err := db.updateDataMigrationState(ctx, tx, dm, status, next); err != nil {
+	expiresAt := time.Now().Add(ttl).Unix()
+
+	res, err := tx.ExecContext(ctx,
+		db.dialect.CommitDataBatchSQL(DataMigrationTableName),
+		status, string(next), expiresAt, dm.Package, dm.Version, owner)
+	if err != nil {
 		return nil, false, rollbackAndLogErr(err, tx, "failed to persist data migration checkpoint")
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return nil, false, rollbackAndLogErr(err, tx, "failed to read affected rows for batch commit")
+	}
+
+	if affected == 0 {
+		// the lease was stolen; discard this batch's work.
+		return nil, false, rollbackAndLogErr(ErrLeaseLost, tx, "data migration lease lost")
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/datamigration_test.go
+++ b/datamigration_test.go
@@ -2,9 +2,11 @@ package rockhopper
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -103,6 +105,33 @@ func countMigrated(t *testing.T, db *DB) int {
 	return c
 }
 
+func mustCursor(t *testing.T, last, max int64) string {
+	t.Helper()
+	b, err := json.Marshal(pkCursor{Last: last, Max: max})
+	require.NoError(t, err)
+	return string(b)
+}
+
+// seedDataMigrationRow inserts a pre-existing state row, used to simulate
+// another process having a lease.
+func seedDataMigrationRow(t *testing.T, db *DB, dm *DataMigration, status, checkpoint, owner string, expiresAt int64) {
+	t.Helper()
+	require.NoError(t, db.TouchDataMigrationTable(context.Background()))
+	_, err := db.Exec(
+		"INSERT INTO "+DataMigrationTableName+" (package, version_id, name, status, checkpoint, lease_owner, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		dm.Package, dm.Version, dm.Name, status, checkpoint, owner, expiresAt)
+	require.NoError(t, err)
+}
+
+func leaseState(t *testing.T, db *DB, dm *DataMigration) (owner sql.NullString, expiresAt int64, status string) {
+	t.Helper()
+	err := db.QueryRow(
+		"SELECT lease_owner, lease_expires_at, status FROM "+DataMigrationTableName+" WHERE package = ? AND version_id = ?",
+		dm.Package, dm.Version).Scan(&owner, &expiresAt, &status)
+	require.NoError(t, err)
+	return owner, expiresAt, status
+}
+
 func TestRunDataMigration_Backfill(t *testing.T) {
 	ctx := context.Background()
 	db := openDataMigrationTestDB(t)
@@ -168,6 +197,125 @@ func TestRunDataMigration_ResumesAfterFailure(t *testing.T) {
 	status, _, _, err = db.loadDataMigrationState(ctx, dm.Package, dm.Version)
 	require.NoError(t, err)
 	assert.Equal(t, DataMigrationCompleted, status)
+}
+
+func TestRunDataMigration_ReleasesLeaseOnComplete(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 5)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000020, Migrator: mig}
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+
+	owner, expiresAt, status := leaseState(t, db, dm)
+	assert.Equal(t, DataMigrationCompleted, status)
+	assert.False(t, owner.Valid, "lease owner should be cleared after completion")
+	assert.EqualValues(t, 0, expiresAt)
+}
+
+func TestRunDataMigration_LeaseHeldByAnother(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000021, Migrator: mig}
+
+	// another process holds a live lease.
+	future := time.Now().Add(1 * time.Hour).Unix()
+	seedDataMigrationRow(t, db, dm, DataMigrationRunning, mustCursor(t, 0, 25), "other-pod", future)
+
+	err := RunDataMigration(ctx, db, dm)
+	assert.ErrorIs(t, err, ErrLeaseHeld)
+
+	assert.Equal(t, 0, countMigrated(t, db))
+	assert.Equal(t, 0, mig.planCalls)
+	assert.Equal(t, 0, mig.batchCalls)
+
+	// the other process's lease must be left untouched.
+	owner, _, _ := leaseState(t, db, dm)
+	assert.Equal(t, "other-pod", owner.String)
+}
+
+func TestRunDataMigration_StealsExpiredLease(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000022, Migrator: mig}
+
+	// a dead process left an expired lease with a running status and checkpoint.
+	past := time.Now().Add(-1 * time.Hour).Unix()
+	seedDataMigrationRow(t, db, dm, DataMigrationRunning, mustCursor(t, 0, 25), "dead-pod", past)
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+
+	assert.Equal(t, 25, countMigrated(t, db))
+	// status was running (not pending), so we resume rather than re-Plan.
+	assert.Equal(t, 0, mig.planCalls)
+
+	owner, _, status := leaseState(t, db, dm)
+	assert.Equal(t, DataMigrationCompleted, status)
+	assert.False(t, owner.Valid)
+}
+
+// leaseStealingMigrator mutates the lease owner from inside a batch to simulate
+// the lease being stolen mid-flight; the guarded commit then affects no rows.
+type leaseStealingMigrator struct {
+	table     string
+	batchSize int64
+}
+
+func (b *leaseStealingMigrator) Plan(ctx context.Context, q Queryer) (Checkpoint, error) {
+	var c pkCursor
+	if err := q.QueryRowContext(ctx, "SELECT COALESCE(MAX(id), 0) FROM "+b.table).Scan(&c.Max); err != nil {
+		return nil, err
+	}
+	return json.Marshal(c)
+}
+
+func (b *leaseStealingMigrator) Batch(ctx context.Context, exec BatchExecutor, cp Checkpoint) (Checkpoint, bool, error) {
+	var c pkCursor
+	if err := json.Unmarshal(cp, &c); err != nil {
+		return nil, false, err
+	}
+
+	hi := c.Last + b.batchSize
+	if _, err := exec.ExecContext(ctx,
+		"UPDATE "+b.table+" SET migrated = 1 WHERE id > ? AND id <= ?", c.Last, hi); err != nil {
+		return nil, false, err
+	}
+
+	// steal the lease from under ourselves (single-row test table).
+	if _, err := exec.ExecContext(ctx,
+		"UPDATE "+DataMigrationTableName+" SET lease_owner = 'thief'"); err != nil {
+		return nil, false, err
+	}
+
+	c.Last = hi
+	next, err := json.Marshal(c)
+	if err != nil {
+		return nil, false, err
+	}
+	return next, c.Last >= c.Max, nil
+}
+
+func TestRunDataMigration_LeaseLostMidBatch(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	mig := &leaseStealingMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000023, Migrator: mig}
+
+	err := RunDataMigration(ctx, db, dm)
+	assert.ErrorIs(t, err, ErrLeaseLost)
+
+	// the in-flight batch was rolled back: no rows committed.
+	assert.Equal(t, 0, countMigrated(t, db))
 }
 
 func TestAddNamedDataMigration(t *testing.T) {

--- a/dialect.go
+++ b/dialect.go
@@ -42,14 +42,26 @@ type SQLDialect interface {
 	// status, checkpoint.
 	InsertDataMigrationSQL(tableName string) string
 
-	// UpdateDataMigrationSQL returns the sql string to update an existing
-	// data-migration state row. Argument order: status, checkpoint, package,
-	// version_id.
-	UpdateDataMigrationSQL(tableName string) string
-
 	// SelectDataMigrationSQL returns the sql string to load the status and
 	// checkpoint of a data migration. Argument order: package, version_id.
 	SelectDataMigrationSQL(tableName string) string
+
+	// AcquireDataMigrationLeaseSQL returns the sql string to conditionally
+	// claim the lease (when unowned, self-owned or expired). Argument order:
+	// owner, expires_at, package, version_id, owner, now. A claim succeeded
+	// when exactly one row was affected.
+	AcquireDataMigrationLeaseSQL(tableName string) string
+
+	// CommitDataBatchSQL returns the sql string to persist a batch's status and
+	// checkpoint while renewing the lease, guarded by ownership. Argument
+	// order: status, checkpoint, expires_at, package, version_id, owner. The
+	// caller still holds the lease when exactly one row was affected.
+	CommitDataBatchSQL(tableName string) string
+
+	// ReleaseDataMigrationLeaseSQL returns the sql string to set a terminal
+	// status and clear the lease, guarded by ownership. Argument order: status,
+	// package, version_id, owner.
+	ReleaseDataMigrationLeaseSQL(tableName string) string
 }
 
 func LoadDialect(d string) (SQLDialect, error) {

--- a/pkg/dialect/mysql.go
+++ b/pkg/dialect/mysql.go
@@ -62,6 +62,8 @@ func (m MySQLDialect) CreateDataMigrationTableSQL(tableName string) string {
                 name VARCHAR(255) NOT NULL DEFAULT '',
                 status VARCHAR(32) NOT NULL DEFAULT 'pending',
                 checkpoint TEXT,
+                lease_owner VARCHAR(255),
+                lease_expires_at BIGINT NOT NULL DEFAULT 0,
                 created_at TIMESTAMP NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
                 PRIMARY KEY(id),
@@ -73,10 +75,21 @@ func (m MySQLDialect) InsertDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES (?, ?, ?, ?, ?)", tableName)
 }
 
-func (m MySQLDialect) UpdateDataMigrationSQL(tableName string) string {
-	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, updated_at = NOW() WHERE package = ? AND version_id = ?", tableName)
-}
-
 func (m MySQLDialect) SelectDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = ? AND version_id = ?", tableName)
+}
+
+func (m MySQLDialect) AcquireDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET lease_owner = ?, lease_expires_at = ?, updated_at = NOW() "+
+		"WHERE package = ? AND version_id = ? AND (lease_owner IS NULL OR lease_owner = ? OR lease_expires_at < ?)", tableName)
+}
+
+func (m MySQLDialect) CommitDataBatchSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, lease_expires_at = ?, updated_at = NOW() "+
+		"WHERE package = ? AND version_id = ? AND lease_owner = ?", tableName)
+}
+
+func (m MySQLDialect) ReleaseDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, lease_owner = NULL, lease_expires_at = 0, updated_at = NOW() "+
+		"WHERE package = ? AND version_id = ? AND lease_owner = ?", tableName)
 }

--- a/pkg/dialect/pgsql.go
+++ b/pkg/dialect/pgsql.go
@@ -62,6 +62,8 @@ func (d PostgresDialect) CreateDataMigrationTableSQL(tableName string) string {
                 name VARCHAR(255) NOT NULL DEFAULT '',
                 status VARCHAR(32) NOT NULL DEFAULT 'pending',
                 checkpoint TEXT,
+                lease_owner VARCHAR(255),
+                lease_expires_at BIGINT NOT NULL DEFAULT 0,
                 created_at TIMESTAMP NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
                 PRIMARY KEY(id),
@@ -73,10 +75,21 @@ func (d PostgresDialect) InsertDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES ($1, $2, $3, $4, $5)", tableName)
 }
 
-func (d PostgresDialect) UpdateDataMigrationSQL(tableName string) string {
-	return fmt.Sprintf("UPDATE %s SET status = $1, checkpoint = $2, updated_at = NOW() WHERE package = $3 AND version_id = $4", tableName)
-}
-
 func (d PostgresDialect) SelectDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = $1 AND version_id = $2", tableName)
+}
+
+func (d PostgresDialect) AcquireDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET lease_owner = $1, lease_expires_at = $2, updated_at = NOW() "+
+		"WHERE package = $3 AND version_id = $4 AND (lease_owner IS NULL OR lease_owner = $5 OR lease_expires_at < $6)", tableName)
+}
+
+func (d PostgresDialect) CommitDataBatchSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = $1, checkpoint = $2, lease_expires_at = $3, updated_at = NOW() "+
+		"WHERE package = $4 AND version_id = $5 AND lease_owner = $6", tableName)
+}
+
+func (d PostgresDialect) ReleaseDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = $1, lease_owner = NULL, lease_expires_at = 0, updated_at = NOW() "+
+		"WHERE package = $2 AND version_id = $3 AND lease_owner = $4", tableName)
 }

--- a/pkg/dialect/redshift.go
+++ b/pkg/dialect/redshift.go
@@ -61,6 +61,8 @@ func (d RedshiftDialect) CreateDataMigrationTableSQL(tableName string) string {
                 name VARCHAR(255) NOT NULL DEFAULT '',
                 status VARCHAR(32) NOT NULL DEFAULT 'pending',
                 checkpoint VARCHAR(65535),
+                lease_owner VARCHAR(255),
+                lease_expires_at BIGINT NOT NULL DEFAULT 0,
                 created_at TIMESTAMP NULL default sysdate,
                 updated_at TIMESTAMP NULL default sysdate,
                 PRIMARY KEY(id)
@@ -71,10 +73,21 @@ func (d RedshiftDialect) InsertDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES ($1, $2, $3, $4, $5)", tableName)
 }
 
-func (d RedshiftDialect) UpdateDataMigrationSQL(tableName string) string {
-	return fmt.Sprintf("UPDATE %s SET status = $1, checkpoint = $2, updated_at = sysdate WHERE package = $3 AND version_id = $4", tableName)
-}
-
 func (d RedshiftDialect) SelectDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = $1 AND version_id = $2", tableName)
+}
+
+func (d RedshiftDialect) AcquireDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET lease_owner = $1, lease_expires_at = $2, updated_at = sysdate "+
+		"WHERE package = $3 AND version_id = $4 AND (lease_owner IS NULL OR lease_owner = $5 OR lease_expires_at < $6)", tableName)
+}
+
+func (d RedshiftDialect) CommitDataBatchSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = $1, checkpoint = $2, lease_expires_at = $3, updated_at = sysdate "+
+		"WHERE package = $4 AND version_id = $5 AND lease_owner = $6", tableName)
+}
+
+func (d RedshiftDialect) ReleaseDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = $1, lease_owner = NULL, lease_expires_at = 0, updated_at = sysdate "+
+		"WHERE package = $2 AND version_id = $3 AND lease_owner = $4", tableName)
 }

--- a/pkg/dialect/sqlite3.go
+++ b/pkg/dialect/sqlite3.go
@@ -60,6 +60,8 @@ func (m Sqlite3Dialect) CreateDataMigrationTableSQL(tableName string) string {
                 name TEXT NOT NULL DEFAULT '',
                 status TEXT NOT NULL DEFAULT 'pending',
                 checkpoint TEXT,
+                lease_owner TEXT,
+                lease_expires_at INTEGER NOT NULL DEFAULT 0,
                 created_at TIMESTAMP DEFAULT (datetime('now')),
                 updated_at TIMESTAMP DEFAULT (datetime('now')),
                 UNIQUE(package, version_id)
@@ -70,10 +72,21 @@ func (m Sqlite3Dialect) InsertDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES (?, ?, ?, ?, ?)", tableName)
 }
 
-func (m Sqlite3Dialect) UpdateDataMigrationSQL(tableName string) string {
-	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, updated_at = datetime('now') WHERE package = ? AND version_id = ?", tableName)
-}
-
 func (m Sqlite3Dialect) SelectDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = ? AND version_id = ?", tableName)
+}
+
+func (m Sqlite3Dialect) AcquireDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET lease_owner = ?, lease_expires_at = ?, updated_at = datetime('now') "+
+		"WHERE package = ? AND version_id = ? AND (lease_owner IS NULL OR lease_owner = ? OR lease_expires_at < ?)", tableName)
+}
+
+func (m Sqlite3Dialect) CommitDataBatchSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, lease_expires_at = ?, updated_at = datetime('now') "+
+		"WHERE package = ? AND version_id = ? AND lease_owner = ?", tableName)
+}
+
+func (m Sqlite3Dialect) ReleaseDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, lease_owner = NULL, lease_expires_at = 0, updated_at = datetime('now') "+
+		"WHERE package = ? AND version_id = ? AND lease_owner = ?", tableName)
 }

--- a/pkg/dialect/tidb.go
+++ b/pkg/dialect/tidb.go
@@ -61,6 +61,8 @@ func (m TiDBDialect) CreateDataMigrationTableSQL(tableName string) string {
                 name VARCHAR(255) NOT NULL DEFAULT '',
                 status VARCHAR(32) NOT NULL DEFAULT 'pending',
                 checkpoint TEXT,
+                lease_owner VARCHAR(255),
+                lease_expires_at BIGINT NOT NULL DEFAULT 0,
                 created_at TIMESTAMP NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
                 PRIMARY KEY(id),
@@ -72,10 +74,21 @@ func (m TiDBDialect) InsertDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("INSERT INTO %s (package, version_id, name, status, checkpoint) VALUES (?, ?, ?, ?, ?)", tableName)
 }
 
-func (m TiDBDialect) UpdateDataMigrationSQL(tableName string) string {
-	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, updated_at = NOW() WHERE package = ? AND version_id = ?", tableName)
-}
-
 func (m TiDBDialect) SelectDataMigrationSQL(tableName string) string {
 	return fmt.Sprintf("SELECT status, checkpoint FROM %s WHERE package = ? AND version_id = ?", tableName)
+}
+
+func (m TiDBDialect) AcquireDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET lease_owner = ?, lease_expires_at = ?, updated_at = NOW() "+
+		"WHERE package = ? AND version_id = ? AND (lease_owner IS NULL OR lease_owner = ? OR lease_expires_at < ?)", tableName)
+}
+
+func (m TiDBDialect) CommitDataBatchSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, checkpoint = ?, lease_expires_at = ?, updated_at = NOW() "+
+		"WHERE package = ? AND version_id = ? AND lease_owner = ?", tableName)
+}
+
+func (m TiDBDialect) ReleaseDataMigrationLeaseSQL(tableName string) string {
+	return fmt.Sprintf("UPDATE %s SET status = ?, lease_owner = NULL, lease_expires_at = 0, updated_at = NOW() "+
+		"WHERE package = ? AND version_id = ? AND lease_owner = ?", tableName)
 }


### PR DESCRIPTION
> **Stacked on #26** (`c9s/data-migration-api`). Review/merge that first; this PR targets that branch and should be rebased onto `main` once #26 lands.

## Summary

Adds a database-backed **lease** so exactly one process drives a given data migration at a time. Without it, a rolling deploy, a retried Kubernetes Job, or two overlapping pods could double-run a backfill. This is the multi-pod safety follow-up called out in #26.

## Mechanism (epoch-based, fully portable — no DB time functions)

- Two new columns on `rockhopper_data_migrations`: `lease_owner` (text) and `lease_expires_at` (bigint, Unix epoch seconds).
- **Owner** = `hostname:pid:nonce`, computed once per process (pod-unique in k8s, since hostname is the pod name).
- **Acquire** = one conditional `UPDATE` (claim when unowned, self-owned, or expired) → `RowsAffected==1` means we won. The loser gets the sentinel `ErrLeaseHeld`.
- **Every batch commit renews the lease and is guarded by `lease_owner = me`, in the same transaction as the work + checkpoint.** If a stalled holder's lease was stolen, the guarded commit affects 0 rows → the in-flight batch is **rolled back** and `ErrLeaseLost` is returned.
- **Release** on completion/failure clears the owner (guarded). A crashed pod's lease expires after the TTL and the next pod **steals it and resumes from the last committed checkpoint**.

## Config

`WithLeaseTTL(d)` option; default `DefaultLeaseTTL = 30s`, renewed on every batch commit. The TTL must exceed a single batch's duration plus the throttle pause.

## Behavior in Kubernetes

A `Job` with `parallelism: 1` is still the recommended shape, but overlap during rolling deploys is now **safe at the DB layer** rather than relying solely on the orchestrator.

## Dialects

Replaced `UpdateDataMigrationSQL` with `AcquireDataMigrationLeaseSQL` / `CommitDataBatchSQL` / `ReleaseDataMigrationLeaseSQL` and added the two lease columns to `CreateDataMigrationTableSQL` across all five dialects (mysql, tidb, sqlite3, postgres, redshift). Since #26 is unreleased, this is just an edit to the same un-shipped table — no schema migration needed.

## Tests

Release-on-complete (owner cleared), held-by-another (`ErrLeaseHeld`, no work, other's lease untouched), steal-expired-lease (resumes + completes), lease-lost-mid-batch (`ErrLeaseLost`, batch rolled back). Full suite + `go vet` clean.

## Follow-ups (not in this PR)

- Reverse dependency: a *contract* schema migration that waits on a data migration's completion.
- CLI integration and data-migration down/rollback semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)