### PR TITLE
FIX: [migration] skip empty statements and add migration context to errors

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -106,7 +106,11 @@ func (m *Migration) runUp(ctx context.Context, db *DB) error {
 	}
 
 	var executor = m.getStmtExecutor()
-	return executor(ctx, db.DB, fn, finalizer)
+	if err := executor(ctx, db.DB, fn, finalizer); err != nil {
+		return errors.Wrapf(err, "up migration failed: %s", m.location())
+	}
+
+	return nil
 }
 
 func (m *Migration) runDown(ctx context.Context, db *DB) error {
@@ -118,7 +122,22 @@ func (m *Migration) runDown(ctx context.Context, db *DB) error {
 	}
 
 	var executor = m.getStmtExecutor()
-	return executor(ctx, db.DB, fn, finalizer)
+	if err := executor(ctx, db.DB, fn, finalizer); err != nil {
+		return errors.Wrapf(err, "down migration failed: %s", m.location())
+	}
+
+	return nil
+}
+
+// location returns a human-readable identifier of the migration for error
+// messages: the source filename when known, plus the version and package.
+func (m *Migration) location() string {
+	source := m.Source
+	if source == "" {
+		source = m.Name
+	}
+
+	return fmt.Sprintf("source=%q version=%d package=%q", source, m.Version, m.Package)
 }
 
 type statementExecution func(ctx context.Context, e SQLExecutor, stmt *Statement) error
@@ -189,11 +208,20 @@ func executeStatement(ctx context.Context, e SQLExecutor, stmt *Statement) error
 	return fn(ctx, e, stmt)
 }
 
-// executeStatements executes the given statements sequentially
+// executeStatements executes the given statements sequentially. Statements that
+// carry no executable SQL (empty, comment-only, or just semicolons) are skipped
+// so leftover queries from merged migration files do not fail execution.
 func executeStatements(ctx context.Context, e SQLExecutor, stmts []Statement) error {
-	for _, stmt := range stmts {
-		if err := executeStatement(ctx, e, &stmt); err != nil {
-			return err
+	for i := range stmts {
+		stmt := &stmts[i]
+
+		if isNoOpSQL(stmt.SQL) {
+			log.Debugf("skipping empty SQL statement #%d", i+1)
+			continue
+		}
+
+		if err := executeStatement(ctx, e, stmt); err != nil {
+			return errors.Wrapf(err, "statement #%d", i+1)
 		}
 	}
 

--- a/migration_test.go
+++ b/migration_test.go
@@ -93,3 +93,119 @@ func TestMigration_UpAndDown(t *testing.T) {
 	err = Down(ctx, db, migrations.Tail(), 0)
 	assert.NoError(t, err)
 }
+
+// TestMigration_SkipsEmptyStatements guards that statements left empty after a
+// migration's queries are merged into another file (empty string, comment-only,
+// or a lone semicolon) are skipped at execution time instead of failing with
+// errors like MySQL 1065 "Query was empty".
+func TestMigration_SkipsEmptyStatements(t *testing.T) {
+	driverName := "sqlite3"
+	dialect, err := LoadDialect(driverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Open(driverName, dialect, ":memory:", TableName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.CurrentVersion(ctx, DefaultPackageName)
+	assert.NoError(t, err)
+
+	migrations := MigrationSlice{
+		{
+			Version: 1,
+			Source:  "migrations/1_merged.sql",
+			UseTx:   true,
+			UpStatements: []Statement{
+				{Direction: DirectionUp, SQL: ""},
+				{Direction: DirectionUp, SQL: "   \n  "},
+				{Direction: DirectionUp, SQL: "-- queries were merged into another file"},
+				{Direction: DirectionUp, SQL: ";"},
+				{Direction: DirectionUp, SQL: "CREATE TABLE kept (id int)"},
+			},
+			DownStatements: []Statement{
+				{Direction: DirectionDown, SQL: ""},
+				{Direction: DirectionDown, SQL: "DROP TABLE kept"},
+			},
+		},
+	}
+
+	migrations = migrations.SortAndConnect()
+
+	err = Up(ctx, db, migrations.Head(), 0)
+	assert.NoError(t, err, "empty statements must be skipped, not executed")
+
+	// the real statement still ran
+	_, err = db.Exec("INSERT INTO kept (id) VALUES (1)")
+	assert.NoError(t, err, "the non-empty statement should have created the table")
+
+	err = Down(ctx, db, migrations.Tail(), 0)
+	assert.NoError(t, err, "empty down statements must be skipped too")
+}
+
+// TestMigration_ErrorIncludesLocation guards that a failing statement surfaces
+// the migration's source filename and version in the error message.
+func TestMigration_ErrorIncludesLocation(t *testing.T) {
+	driverName := "sqlite3"
+	dialect, err := LoadDialect(driverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Open(driverName, dialect, ":memory:", TableName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	_, err = db.CurrentVersion(ctx, DefaultPackageName)
+	assert.NoError(t, err)
+
+	migrations := MigrationSlice{
+		{
+			Version: 20240131120000,
+			Source:  "migrations/20240131120000_broken.sql",
+			Package: DefaultPackageName,
+			UseTx:   true,
+			UpStatements: []Statement{
+				{Direction: DirectionUp, SQL: "THIS IS NOT VALID SQL"},
+			},
+		},
+	}
+
+	migrations = migrations.SortAndConnect()
+
+	err = Up(ctx, db, migrations.Head(), 0)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "20240131120000_broken.sql")
+		assert.Contains(t, err.Error(), "20240131120000")
+	}
+}
+
+func TestIsNoOpSQL(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{"empty", "", true},
+		{"whitespace", "   \n\t ", true},
+		{"lone semicolon", ";", true},
+		{"multiple semicolons", "; ;\n;", true},
+		{"comment only", "-- a comment", true},
+		{"comment with semicolon", "-- a comment\n;", true},
+		{"real statement", "CREATE TABLE t (id int);", false},
+		{"statement with trailing comment", "SELECT 1; -- note", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNoOpSQL(tt.sql))
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -17,6 +17,15 @@ func cleanSQL(s string) string {
 	return strings.TrimSpace(matchEmptyEOL.ReplaceAllString(s, ""))
 }
 
+// isNoOpSQL reports whether the statement carries no executable SQL — it is
+// empty, whitespace-only, contains only SQL comments, or is just semicolons.
+// Such statements can be left behind when migration queries are merged into
+// other files; executing them would trigger errors like MySQL 1065
+// "Query was empty".
+func isNoOpSQL(s string) bool {
+	return strings.Trim(cleanSQL(s), "; \t\r\n") == ""
+}
+
 func previewSQL(s string) string {
 	s = matchNewLinesAndSpaces.ReplaceAllString(s, " ")
 


### PR DESCRIPTION
Two execution-time fixes for migrations whose queries were merged into other files, leaving behind empty statements:

1. Skip no-op statements (empty, whitespace-only, comment-only, or just semicolons) at execution time instead of sending them to the database, which would fail with errors like MySQL 1065 "Query was empty". The migration is still detected and its remaining statements run normally.

2. Wrap execution failures with the migration source filename, version, and package, and annotate the failing statement with its ordinal, so errors point at the offending migration instead of just an opaque SQL error.