### PR TITLE
db: auto-enable parseTime=true for MySQL DSNs

### DIFF
--- a/db.go
+++ b/db.go
@@ -98,6 +98,13 @@ func OpenWithEnv(prefix string) (*DB, error) {
 	return Open(driverName, dialect, dsn, TableName)
 }
 
+// normalizeMySQLDSN, when set, rewrites a MySQL DSN so that parseTime=true is
+// enabled. rockhopper scans the version table's tstamp column into time.Time,
+// which requires parseTime=true; without it the driver returns the raw []byte
+// and scanning fails. It is registered by driver_mysql.go and stays nil when
+// the MySQL driver is excluded from the build (the no_mysql build tag).
+var normalizeMySQLDSN func(dsn string) (string, error)
+
 // Open creates a connection to a database
 func Open(driverName string, dialect SQLDialect, dsn string, tableName string) (*DB, error) {
 	driverName = castDriverName(driverName)
@@ -107,6 +114,17 @@ func Open(driverName string, dialect SQLDialect, dsn string, tableName string) (
 	case DialectPostgres, DialectSQLite3, DialectMySQL:
 	default:
 		return nil, fmt.Errorf("unsupported driver %s", driverName)
+	}
+
+	// Ensure parseTime=true is set for MySQL/TiDB so DATETIME/TIMESTAMP columns
+	// scan into time.Time. castDriverName has already folded TiDB into MySQL.
+	if driverName == DialectMySQL && dsn != "" && normalizeMySQLDSN != nil {
+		normalized, err := normalizeMySQLDSN(dsn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse mysql dsn: %q: %w", maskDsnPassword(dsn), err)
+		}
+
+		dsn = normalized
 	}
 
 	db, err := sql.Open(driverName, dsn)

--- a/driver_mysql.go
+++ b/driver_mysql.go
@@ -4,5 +4,25 @@
 package rockhopper
 
 import (
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
+	log "github.com/sirupsen/logrus"
 )
+
+// Importing the driver (even via this non-blank import) runs its init and
+// registers the "mysql" driver with database/sql. We additionally register a
+// DSN normalizer so Open can guarantee parseTime=true.
+func init() {
+	normalizeMySQLDSN = func(dsn string) (string, error) {
+		cfg, err := mysql.ParseDSN(dsn)
+		if err != nil {
+			return dsn, err
+		}
+
+		if !cfg.ParseTime {
+			cfg.ParseTime = true
+			log.Debug("mysql dsn: enabling parseTime=true so DATETIME/TIMESTAMP columns scan into time.Time")
+		}
+
+		return cfg.FormatDSN(), nil
+	}
+}

--- a/driver_mysql_test.go
+++ b/driver_mysql_test.go
@@ -1,0 +1,65 @@
+//go:build !no_mysql
+// +build !no_mysql
+
+package rockhopper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeMySQLDSN_ParseTime guards that the DSN normalizer registered by
+// the MySQL driver always yields parseTime=true, which rockhopper needs so the
+// version table's tstamp column scans into time.Time.
+func TestNormalizeMySQLDSN_ParseTime(t *testing.T) {
+	require.NotNil(t, normalizeMySQLDSN, "the MySQL driver must register the DSN normalizer")
+
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "adds parseTime when missing",
+			dsn:  "root:pass@tcp(127.0.0.1:3306)/test",
+			want: "root:pass@tcp(127.0.0.1:3306)/test?parseTime=true",
+		},
+		{
+			name: "keeps parseTime when already set",
+			dsn:  "root:pass@tcp(127.0.0.1:3306)/test?parseTime=true",
+			want: "root:pass@tcp(127.0.0.1:3306)/test?parseTime=true",
+		},
+		{
+			name: "appends parseTime alongside other params",
+			dsn:  "root:pass@tcp(127.0.0.1:3306)/test?charset=utf8mb4",
+			want: "root:pass@tcp(127.0.0.1:3306)/test?charset=utf8mb4&parseTime=true",
+		},
+		{
+			name: "preserves unix socket",
+			dsn:  "root:pass@unix(/tmp/mysql.sock)/test",
+			want: "root:pass@unix(/tmp/mysql.sock)/test?parseTime=true",
+		},
+		{
+			name: "no database name",
+			dsn:  "root@tcp(127.0.0.1:3306)/",
+			want: "root@tcp(127.0.0.1:3306)/?parseTime=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeMySQLDSN(tt.dsn)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeMySQLDSN_Invalid(t *testing.T) {
+	require.NotNil(t, normalizeMySQLDSN)
+
+	_, err := normalizeMySQLDSN("::::not a dsn")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Running `status` (and other commands) against MySQL without `parseTime=true` in the DSN fails:

```
Error: sql: Scan error on column index 1, name "tstamp": unsupported Scan,
storing driver.Value type []uint8 into type *time.Time
```

rockhopper scans the version table's `tstamp` column into `time.Time`, which requires the go-sql-driver `parseTime=true` option. Previously users had to remember to add it to their DSN by hand.

`Open` now normalizes MySQL/TiDB DSNs to guarantee `parseTime=true`, using the driver's own `mysql.ParseDSN`/`FormatDSN` so it correctly handles existing query params, unix sockets, and missing database names.

## Design

- The normalization happens in `Open`, the single chokepoint all connection paths (`OpenWithConfig`, `OpenWithEnv`, direct) funnel through. `castDriverName` has already folded TiDB into MySQL at that point, so TiDB is covered too.
- To keep `db.go` free of a hard MySQL import (and respect the existing `no_mysql` build tag), the normalizer is registered via a hook from `driver_mysql.go`. Under `no_mysql` the hook stays nil and `Open` leaves the DSN untouched.
- An already-present `parseTime=true` is preserved; other params (e.g. `charset=utf8mb4`) are kept and `parseTime` is appended.

## Tests

`driver_mysql_test.go` (build-tagged `!no_mysql`) covers: adding `parseTime` when missing, preserving it when set, appending alongside other params, unix-socket DSNs, no-database DSNs, and the invalid-DSN error path.

Verified `go build`/`go test` pass under both the default and `-tags no_mysql` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)