### PR TITLE
refactor: move SQL driver registration into pkg/driver

### DIFF
--- a/db.go
+++ b/db.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/c9s/rockhopper/v2/pkg/dialect"
+	"github.com/c9s/rockhopper/v2/pkg/driver"
 )
 
 const (
@@ -98,13 +99,6 @@ func OpenWithEnv(prefix string) (*DB, error) {
 	return Open(driverName, dialect, dsn, TableName)
 }
 
-// normalizeMySQLDSN, when set, rewrites a MySQL DSN so that parseTime=true is
-// enabled. rockhopper scans the version table's tstamp column into time.Time,
-// which requires parseTime=true; without it the driver returns the raw []byte
-// and scanning fails. It is registered by driver_mysql.go and stays nil when
-// the MySQL driver is excluded from the build (the no_mysql build tag).
-var normalizeMySQLDSN func(dsn string) (string, error)
-
 // Open creates a connection to a database
 func Open(driverName string, dialect SQLDialect, dsn string, tableName string) (*DB, error) {
 	driverName = castDriverName(driverName)
@@ -118,8 +112,8 @@ func Open(driverName string, dialect SQLDialect, dsn string, tableName string) (
 
 	// Ensure parseTime=true is set for MySQL/TiDB so DATETIME/TIMESTAMP columns
 	// scan into time.Time. castDriverName has already folded TiDB into MySQL.
-	if driverName == DialectMySQL && dsn != "" && normalizeMySQLDSN != nil {
-		normalized, err := normalizeMySQLDSN(dsn)
+	if driverName == DialectMySQL && dsn != "" && driver.NormalizeMySQLDSN != nil {
+		normalized, err := driver.NormalizeMySQLDSN(dsn)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse mysql dsn: %q: %w", maskDsnPassword(dsn), err)
 		}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1,0 +1,16 @@
+// Package driver bundles the supported SQL drivers (MySQL, PostgreSQL and
+// SQLite3) so that importing it registers them with the database/sql package.
+// Each driver lives in its own file guarded by a build tag (no_mysql,
+// no_postgres, no_sqlite3) so it can be excluded at build time.
+//
+// This file carries no build constraints, ensuring the package always has at
+// least one Go file and that NormalizeMySQLDSN is always declared, even when
+// every driver is excluded from the build.
+package driver
+
+// NormalizeMySQLDSN, when set, rewrites a MySQL DSN so that parseTime=true is
+// enabled. rockhopper scans the version table's tstamp column into time.Time,
+// which requires parseTime=true; without it the driver returns the raw []byte
+// and scanning fails. It is registered by mysql.go's init and stays nil when
+// the MySQL driver is excluded from the build (the no_mysql build tag).
+var NormalizeMySQLDSN func(dsn string) (string, error)

--- a/pkg/driver/mysql.go
+++ b/pkg/driver/mysql.go
@@ -1,5 +1,4 @@
 //go:build !no_mysql
-// +build !no_mysql
 
 package driver
 

--- a/pkg/driver/mysql.go
+++ b/pkg/driver/mysql.go
@@ -1,7 +1,7 @@
 //go:build !no_mysql
 // +build !no_mysql
 
-package rockhopper
+package driver
 
 import (
 	"github.com/go-sql-driver/mysql"
@@ -12,7 +12,7 @@ import (
 // registers the "mysql" driver with database/sql. We additionally register a
 // DSN normalizer so Open can guarantee parseTime=true.
 func init() {
-	normalizeMySQLDSN = func(dsn string) (string, error) {
+	NormalizeMySQLDSN = func(dsn string) (string, error) {
 		cfg, err := mysql.ParseDSN(dsn)
 		if err != nil {
 			return dsn, err

--- a/pkg/driver/mysql_test.go
+++ b/pkg/driver/mysql_test.go
@@ -1,7 +1,7 @@
 //go:build !no_mysql
 // +build !no_mysql
 
-package rockhopper
+package driver
 
 import (
 	"testing"
@@ -14,7 +14,7 @@ import (
 // the MySQL driver always yields parseTime=true, which rockhopper needs so the
 // version table's tstamp column scans into time.Time.
 func TestNormalizeMySQLDSN_ParseTime(t *testing.T) {
-	require.NotNil(t, normalizeMySQLDSN, "the MySQL driver must register the DSN normalizer")
+	require.NotNil(t, NormalizeMySQLDSN, "the MySQL driver must register the DSN normalizer")
 
 	tests := []struct {
 		name string
@@ -50,7 +50,7 @@ func TestNormalizeMySQLDSN_ParseTime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := normalizeMySQLDSN(tt.dsn)
+			got, err := NormalizeMySQLDSN(tt.dsn)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -58,8 +58,8 @@ func TestNormalizeMySQLDSN_ParseTime(t *testing.T) {
 }
 
 func TestNormalizeMySQLDSN_Invalid(t *testing.T) {
-	require.NotNil(t, normalizeMySQLDSN)
+	require.NotNil(t, NormalizeMySQLDSN)
 
-	_, err := normalizeMySQLDSN("::::not a dsn")
+	_, err := NormalizeMySQLDSN("::::not a dsn")
 	assert.Error(t, err)
 }

--- a/pkg/driver/pgsql.go
+++ b/pkg/driver/pgsql.go
@@ -1,7 +1,7 @@
 //go:build !no_postgres
 // +build !no_postgres
 
-package rockhopper
+package driver
 
 import (
 	_ "github.com/lib/pq"

--- a/pkg/driver/pgsql.go
+++ b/pkg/driver/pgsql.go
@@ -1,5 +1,4 @@
 //go:build !no_postgres
-// +build !no_postgres
 
 package driver
 

--- a/pkg/driver/sqlite3.go
+++ b/pkg/driver/sqlite3.go
@@ -1,5 +1,4 @@
 //go:build !no_sqlite3
-// +build !no_sqlite3
 
 package driver
 

--- a/pkg/driver/sqlite3.go
+++ b/pkg/driver/sqlite3.go
@@ -1,7 +1,7 @@
 //go:build !no_sqlite3
 // +build !no_sqlite3
 
-package rockhopper
+package driver
 
 import (
 	_ "github.com/mattn/go-sqlite3"


### PR DESCRIPTION
## Summary

Moves the SQL driver registration files out of the root package into a dedicated `pkg/driver` package, so the driver wiring lives in one organized place.

| Before (root, `package rockhopper`) | After (`pkg/driver`, `package driver`) |
|---|---|
| `driver_mysql.go` | `pkg/driver/mysql.go` |
| `driver_pgsql.go` | `pkg/driver/pgsql.go` |
| `driver_sqlite3.go` | `pkg/driver/sqlite3.go` |
| `driver_mysql_test.go` | `pkg/driver/mysql_test.go` |

## Why the small `db.go` change

`driver_mysql.go`'s `init()` used to assign an **unexported** `normalizeMySQLDSN` hook declared in `db.go`. Simply moving the driver to its own package would require `pkg/driver` to import the root package while the root package imports `pkg/driver` — an **import cycle**.

To avoid it, ownership of the hook now lives in `pkg/driver` as the exported `NormalizeMySQLDSN` var, and `db.go` reads it. This gives a single dependency direction (`rockhopper` → `pkg/driver`). That same import also auto-registers the bundled drivers, preserving the existing behavior the test suite relies on.

An unconstrained `pkg/driver/driver.go` declares `NormalizeMySQLDSN` and keeps the package compiling when every driver is excluded via the `no_mysql` / `no_postgres` / `no_sqlite3` build tags.

## Testing

- `go build ./...`
- `go build -tags 'no_mysql no_postgres no_sqlite3' ./...` (driver-exclusion build still works)
- `go vet ./...`
- `go test ./...` — all packages pass, including the relocated normalizer test under `pkg/driver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)