### PR TITLE
fix(create): resolve migrations dir from migrationsDirs with default fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ includePackages:                 # Optional: only include these packages
 | `dialect` | same as driver | SQL dialect for query generation. Also supports `tidb` (uses mysql) and `redshift` (uses postgres) |
 | `dsn` | | Data source name / connection string |
 | `package` | `main` | Default migration package name |
-| `migrationsDir` | `migrations` | Single migration directory (use `migrationsDirs` for multiple) |
-| `migrationsDirs` | | List of migration directories |
+| `migrationsDir` | | **Legacy**, for Goose compatibility (Goose uses a single directory). Prefer `migrationsDirs`; a value set here is migrated into `migrationsDirs` as its first entry. |
+| `migrationsDirs` | `migrations` | List of migration directories. `create` writes new migrations to the first directory. |
 | `includePackages` | all | Whitelist of packages to include when loading migrations |
 
 > The version-tracking table is always named `rockhopper_versions` when using the CLI. To use a custom table name, call the library's `Open` / `New` functions directly and pass your own name (see [Go API](#go-api)).

--- a/cmd/rockhopper/create.go
+++ b/cmd/rockhopper/create.go
@@ -40,12 +40,8 @@ func create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if outputDir == "" && config.MigrationsDir != "" {
-		outputDir = config.MigrationsDir
-	}
-
 	if outputDir == "" {
-		outputDir = "migrations"
+		outputDir = defaultMigrationsDir(config)
 	}
 
 	if !dirExists(outputDir) {
@@ -55,6 +51,19 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	return rockhopper.CreateWithTemplate(outputDir, nil, args[0], templateType)
+}
+
+// defaultMigrationsDir resolves the directory new migration files are written to
+// when --output is not given. LoadConfig migrates the legacy goose-compatible
+// `migrationsDir` into `migrationsDirs`, so that list is the single source of
+// truth here; the first directory is used. It falls back to "migrations" when no
+// directory is configured.
+func defaultMigrationsDir(config *rockhopper.Config) string {
+	if len(config.MigrationsDirs) > 0 {
+		return config.MigrationsDirs[0]
+	}
+
+	return "migrations"
 }
 
 func dirExists(filename string) bool {

--- a/cmd/rockhopper/create_test.go
+++ b/cmd/rockhopper/create_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/rockhopper/v2"
+)
+
+func TestDefaultMigrationsDir(t *testing.T) {
+	t.Run("no directory configured falls back to migrations", func(t *testing.T) {
+		assert.Equal(t, "migrations", defaultMigrationsDir(&rockhopper.Config{}))
+	})
+
+	t.Run("legacy migrationsDir is honored", func(t *testing.T) {
+		// LoadConfig migrates a non-empty MigrationsDir into MigrationsDirs, so a
+		// legacy goose-style config arrives here as a one-element list.
+		assert.Equal(t, "migrations/sqlite3", defaultMigrationsDir(&rockhopper.Config{
+			MigrationsDirs: []string{"migrations/sqlite3"},
+		}))
+	})
+
+	t.Run("first of multiple migrationsDirs is used", func(t *testing.T) {
+		assert.Equal(t, "migrations/mysql/app1", defaultMigrationsDir(&rockhopper.Config{
+			MigrationsDirs: []string{"migrations/mysql/app1", "migrations/mysql/app2"},
+		}))
+	})
+}

--- a/config.go
+++ b/config.go
@@ -14,8 +14,17 @@ type Config struct {
 
 	Package string `json:"package" yaml:"package"`
 
+	// MigrationsDir is the legacy single migration directory. It exists for
+	// compatibility with goose, which uses this single-directory field. New
+	// configuration should use MigrationsDirs instead; LoadConfig migrates a
+	// non-empty MigrationsDir into MigrationsDirs.
+	//
+	// Deprecated: use MigrationsDirs.
 	MigrationsDir string `json:"migrationsDir" yaml:"migrationsDir" env:"ROCKHOPPER_MIGRATIONS_DIR"`
 
+	// MigrationsDirs is the list of directories rockhopper scans for migrations.
+	// It supersedes MigrationsDir and supports multiple directories (e.g. one per
+	// package). When creating a new migration, the first directory is used.
 	MigrationsDirs []string `json:"migrationsDirs" yaml:"migrationsDirs" env:"ROCKHOPPER_MIGRATIONS_DIRS"`
 
 	TableName string `json:"tableName" yaml:"tableName" env:"ROCKHOPPER_TABLE_NAME"`
@@ -49,8 +58,21 @@ func LoadConfig(configFile string) (*Config, error) {
 		return nil, err
 	}
 
+	// Migrate the legacy goose-compatible single directory into MigrationsDirs so
+	// the rest of the code only has to consult one field. It is prepended so the
+	// legacy directory stays first, preserving the single-directory expectation of
+	// configs that only set MigrationsDir.
 	if len(config.MigrationsDir) > 0 {
-		config.MigrationsDirs = append(config.MigrationsDirs, config.MigrationsDir)
+		config.MigrationsDirs = append([]string{config.MigrationsDir}, config.MigrationsDirs...)
+	}
+
+	// Fall back to a single default "migrations" directory when none is
+	// configured. Small applications often need only one directory and shouldn't
+	// have to set migrationsDir/migrationsDirs at all. Centralizing the fallback
+	// here keeps every command consistent: create writes to "migrations" and
+	// up/status/down/etc. load from the same place.
+	if len(config.MigrationsDirs) == 0 {
+		config.MigrationsDirs = []string{"migrations"}
 	}
 
 	return &config, err

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,40 @@ func writeTempConfig(t *testing.T, content string) string {
 	return path
 }
 
+func TestLoadConfig_MigratesLegacyMigrationsDir(t *testing.T) {
+	t.Run("legacy-only config becomes a single-element list", func(t *testing.T) {
+		path := writeTempConfig(t, "driver: sqlite3\nmigrationsDir: migrations/sqlite3\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, []string{"migrations/sqlite3"}, config.MigrationsDirs)
+		}
+	})
+
+	t.Run("legacy dir is prepended so it stays first", func(t *testing.T) {
+		path := writeTempConfig(t, "driver: mysql\nmigrationsDir: legacy/dir\nmigrationsDirs:\n- modern/a\n- modern/b\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, []string{"legacy/dir", "modern/a", "modern/b"}, config.MigrationsDirs)
+		}
+	})
+
+	t.Run("migrationsDirs only is left untouched", func(t *testing.T) {
+		path := writeTempConfig(t, "driver: mysql\nmigrationsDirs:\n- a\n- b\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, []string{"a", "b"}, config.MigrationsDirs)
+		}
+	})
+
+	t.Run("no directory configured falls back to migrations", func(t *testing.T) {
+		path := writeTempConfig(t, "driver: sqlite3\n")
+		config, err := LoadConfig(path)
+		if assert.NoError(t, err) {
+			assert.Equal(t, []string{"migrations"}, config.MigrationsDirs)
+		}
+	})
+}
+
 func TestLoadConfig_ExpandsEnv(t *testing.T) {
 	t.Run("braced form", func(t *testing.T) {
 		t.Setenv("MYSQL8_URL", "root@tcp(localhost:3306)/db?parseTime=true")


### PR DESCRIPTION
## Summary

`rockhopper create` without `--output` only consulted the singular `migrationsDir`, so a config that set only `migrationsDirs` (e.g. `rockhopper_mysql.yaml`) silently fell back to a hardcoded `"migrations"` directory and wrote the new file to the wrong place.

This PR makes `MigrationsDirs` the single source of truth and fixes the resolution end to end.

## Changes

- **`migrationsDir` is now the legacy, goose-compatible field** (goose uses a single directory). It's documented as such and marked `// Deprecated:`. `LoadConfig` migrates a non-empty `migrationsDir` into `migrationsDirs`, **prepended** so it stays first.
- **`create` writes to the first entry of `migrationsDirs`** (`defaultMigrationsDir`).
- **Default `"migrations"` fallback is preserved and centralized in `LoadConfig`.** When nothing is configured, `MigrationsDirs` becomes `["migrations"]`. Putting the fallback here keeps `create` and the load commands (`up`/`status`/`down`/`redo`/`compile`/`align`, which all call `loader.Load(config.MigrationsDirs...)`) consistent — small single-directory apps work with no `migrationsDir`/`migrationsDirs` setting at all.

Resolution order: `migrationsDirs[0]` → migrated legacy `migrationsDir` → `migrations` fallback.

## Tests

- `TestLoadConfig_MigratesLegacyMigrationsDir` — legacy-only → single-element list; legacy + plural → legacy prepended; plural-only untouched; nothing configured → `["migrations"]`.
- `TestDefaultMigrationsDir` — fallback, legacy honored, first-of-multiple.
- README config table updated. `go build`, `go vet`, and `go test ./...` all pass.

## Behavior note

If you run a load command with no migrations directory configured **and** no `migrations/` folder on disk, `LoadDir` now errors with `directory "migrations" does not exists` instead of silently doing nothing. Arguably more helpful, but it is a behavior change worth flagging.

## Base

Targets `c9s/docs-go-migrations` (PR #37) since it builds on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)