### PR TITLE
feat(datamigration): package-aware deps, batch retries, safe checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,25 @@ func init() {
 }
 ```
 
+A data migration belongs to a **package**, the same namespace your schema
+migrations use. `AddDataMigration` defaults the package to `"main"` (the default
+package of SQL scripts), so a Go data migration registered alongside plain SQL
+migrations lands in the same namespace by default. When your schema lives in a
+different package, set it together with the name:
+
+```go
+rockhopper.WithDataMigrationName("backfill_users", "orders"),  // name + package
+```
+
+The `After` dependency is resolved **within the data migration's own package**.
+Pass a package as the second argument to depend on a schema version in a
+*different* package:
+
+```go
+rockhopper.After(20240116231445)          // schema version 20240116231445 in this migration's package
+rockhopper.After(20240116231445, "core")  // ... in the "core" package instead
+```
+
 Then drive them to completion. Each call is safe to repeat: completed migrations
 are skipped and interrupted ones resume.
 

--- a/datamigration.go
+++ b/datamigration.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -143,10 +142,16 @@ type DataMigration struct {
 	// Migrator holds the user-provided batch logic.
 	Migrator DataMigrator
 
-	// After is the schema migration version (same package) that must be applied
-	// before this data migration becomes eligible to run. Zero means no
-	// dependency.
+	// After is the schema migration version that must be applied before this
+	// data migration becomes eligible to run. Zero means no dependency. The
+	// schema version is looked up in AfterPackage (see afterPackage).
 	After int64
+
+	// AfterPackage is the package of the schema migration named by After. When
+	// empty, the dependency is resolved against this data migration's own
+	// Package (see afterPackage). Set it to depend on a schema version in a
+	// different package.
+	AfterPackage string
 
 	// Throttle is the pause inserted between batches to limit load and
 	// replication lag. Zero means no pause.
@@ -156,6 +161,19 @@ type DataMigration struct {
 	// may steal it. It is renewed on every batch commit. Zero means
 	// DefaultLeaseTTL. It must exceed a single batch's duration plus Throttle.
 	LeaseTTL time.Duration
+}
+
+// afterPackage returns the package that the After schema version is looked up
+// in: the explicitly configured AfterPackage when set, otherwise the data
+// migration's own Package (which defaults to DefaultPackageName). This lets
+// After(version) target the data migration's package without restating it,
+// while After(version, pkg) targets a different package.
+func (dm *DataMigration) afterPackage() string {
+	if dm.AfterPackage != "" {
+		return dm.AfterPackage
+	}
+
+	return dm.Package
 }
 
 func (dm *DataMigration) leaseTTL() time.Duration {
@@ -178,10 +196,16 @@ func (dm *DataMigration) String() string {
 type DataMigrationOption func(*DataMigration)
 
 // After declares that the data migration may only run once the given schema
-// migration version (in the same package) has been applied.
-func After(schemaVersion int64) DataMigrationOption {
+// migration version has been applied. Without packageName, the version is
+// looked up in the data migration's own package (which defaults to
+// DefaultPackageName); pass packageName to depend on a schema version in a
+// different package. Only the first packageName is used.
+func After(schemaVersion int64, packageName ...string) DataMigrationOption {
 	return func(dm *DataMigration) {
 		dm.After = schemaVersion
+		if len(packageName) > 0 {
+			dm.AfterPackage = packageName[0]
+		}
 	}
 }
 
@@ -192,10 +216,16 @@ func WithThrottle(d time.Duration) DataMigrationOption {
 	}
 }
 
-// WithDataMigrationName sets a human-readable description.
-func WithDataMigrationName(name string) DataMigrationOption {
+// WithDataMigrationName sets a human-readable description and, optionally, the
+// data migration's package. Passing the package here is a convenience for the
+// common case of aligning the data migration with the SQL/schema package it
+// sits beside (e.g. "main"). Only the first packageName is used.
+func WithDataMigrationName(name string, packageName ...string) DataMigrationOption {
 	return func(dm *DataMigration) {
 		dm.Name = name
+		if len(packageName) > 0 {
+			dm.Package = packageName[0]
+		}
 	}
 }
 
@@ -213,20 +243,14 @@ func WithLeaseTTL(d time.Duration) DataMigrationOption {
 var registeredDataMigrations = map[RegistryKey]*DataMigration{}
 
 // AddDataMigration registers a data migration into the global map. The version
-// is parsed from the caller's source filename and the package is derived from
-// the caller's function name, mirroring AddMigration.
+// is parsed from the caller's source filename and the package defaults to
+// DefaultPackageName, matching the default package of SQL migrations so a Go
+// data migration sits in the same namespace as the scripts it accompanies. Set
+// a different package with WithDataMigrationName(name, packageName) or use
+// AddNamedDataMigration.
 func AddDataMigration(m DataMigrator, opts ...DataMigrationOption) {
-	pc, filename, _, _ := runtime.Caller(1)
-
-	funcName := runtime.FuncForPC(pc).Name()
-	lastSlash := strings.LastIndexByte(funcName, '/')
-	if lastSlash < 0 {
-		lastSlash = 0
-	}
-
-	lastDot := strings.LastIndexByte(funcName[lastSlash:], '.') + lastSlash
-	packageName := funcName[:lastDot]
-	AddNamedDataMigration(packageName, filename, m, opts...)
+	_, filename, _, _ := runtime.Caller(1)
+	AddNamedDataMigration(DefaultPackageName, filename, m, opts...)
 }
 
 // AddNamedDataMigration registers a data migration with an explicit package and

--- a/datamigration_run.go
+++ b/datamigration_run.go
@@ -198,13 +198,14 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 
 	// dependency gate: the mapped schema migration must be applied first.
 	if dm.After > 0 {
-		applied, err := db.isSchemaVersionApplied(ctx, dm.Package, dm.After)
+		afterPkg := dm.afterPackage()
+		applied, err := db.isSchemaVersionApplied(ctx, afterPkg, dm.After)
 		if err != nil {
 			return err
 		}
 
 		if !applied {
-			return fmt.Errorf("data migration %s depends on schema version %d which is not applied yet", dm, dm.After)
+			return fmt.Errorf("data migration %s depends on schema version %s:%d which is not applied yet", dm, afterPkg, dm.After)
 		}
 	}
 

--- a/datamigration_test.go
+++ b/datamigration_test.go
@@ -363,3 +363,109 @@ func TestRunDataMigration_DependencyGate(t *testing.T) {
 	require.NoError(t, RunDataMigration(ctx, db, dm))
 	assert.Equal(t, 5, countMigrated(t, db))
 }
+
+func TestAfterOption_TargetPackage(t *testing.T) {
+	t.Run("defaults to the data migration's own package", func(t *testing.T) {
+		dm := &DataMigration{Package: "orders"}
+		After(1700000000000000)(dm)
+
+		assert.Equal(t, int64(1700000000000000), dm.After)
+		assert.Empty(t, dm.AfterPackage, "no explicit package configured")
+		assert.Equal(t, "orders", dm.afterPackage(), "falls back to the data migration package")
+	})
+
+	t.Run("explicit package targets a different package", func(t *testing.T) {
+		dm := &DataMigration{Package: "orders"}
+		After(1700000000000000, "core")(dm)
+
+		assert.Equal(t, "core", dm.AfterPackage)
+		assert.Equal(t, "core", dm.afterPackage())
+	})
+}
+
+func TestWithDataMigrationName_SetsPackage(t *testing.T) {
+	dm := &DataMigration{Package: "derived"}
+	WithDataMigrationName("backfill users", "main")(dm)
+	assert.Equal(t, "backfill users", dm.Name)
+	assert.Equal(t, "main", dm.Package, "package argument overrides the existing package")
+
+	keep := &DataMigration{Package: "keepme"}
+	WithDataMigrationName("name only")(keep)
+	assert.Equal(t, "name only", keep.Name)
+	assert.Equal(t, "keepme", keep.Package, "package is left untouched when omitted")
+}
+
+// TestRunDataMigration_DependencyGateDefaultPackage verifies that After(v)
+// without an explicit package resolves the schema version against the data
+// migration's own package, not a hard-coded default.
+func TestRunDataMigration_DependencyGateDefaultPackage(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 5)
+	require.NoError(t, db.Touch(ctx))
+
+	const schemaVersion = int64(1699999999999998)
+	dm := &DataMigration{
+		Package:  "orders",
+		Version:  1700000000000005,
+		Migrator: &backfillMigrator{table: "users", batchSize: 10},
+		After:    schemaVersion,
+	}
+
+	// schema version applied under "main" (the wrong package) must not satisfy
+	// a dependency that targets the "orders" package.
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	require.NoError(t, db.insertVersion(ctx, tx, DefaultPackageName, "", schemaVersion, true))
+	require.NoError(t, tx.Commit())
+
+	require.Error(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 0, countMigrated(t, db))
+
+	// applying it under "orders" satisfies the gate.
+	tx, err = db.Begin()
+	require.NoError(t, err)
+	require.NoError(t, db.insertVersion(ctx, tx, "orders", "", schemaVersion, true))
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 5, countMigrated(t, db))
+}
+
+// TestRunDataMigration_DependencyGateCrossPackage verifies that After(v, pkg)
+// resolves the schema version against the explicitly named package, which may
+// differ from the data migration's own package.
+func TestRunDataMigration_DependencyGateCrossPackage(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 5)
+	require.NoError(t, db.Touch(ctx))
+
+	const schemaVersion = int64(1699999999999997)
+	dm := &DataMigration{
+		Package:      DefaultPackageName,
+		Version:      1700000000000006,
+		Migrator:     &backfillMigrator{table: "users", batchSize: 10},
+		After:        schemaVersion,
+		AfterPackage: "core",
+	}
+
+	// applying the version under the data migration's own package ("main") is
+	// not enough; the dependency targets "core".
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	require.NoError(t, db.insertVersion(ctx, tx, DefaultPackageName, "", schemaVersion, true))
+	require.NoError(t, tx.Commit())
+
+	require.Error(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 0, countMigrated(t, db))
+
+	// applying it under "core" satisfies the gate.
+	tx, err = db.Begin()
+	require.NoError(t, err)
+	require.NoError(t, db.insertVersion(ctx, tx, "core", "", schemaVersion, true))
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 5, countMigrated(t, db))
+}


### PR DESCRIPTION
Improvements to the data-migration (data migrator) runner. Two commits.

## 1. Package-aware dependencies & explicit package

`AddDataMigration` derived its package from the Go runtime function name, which mismatched SQL scripts' default `"main"` package. The `After` dependency was then resolved under the derived name and never found the applied schema version.

- **Default package is now `"main"`** (`DefaultPackageName`) so a Go data migration shares the namespace of the SQL scripts it accompanies. The caller's filename is still used for version parsing.
- **`WithDataMigrationName(name, ...pkg)`** — optional package set alongside the name.
- **`After(version, ...pkg)`** — optional target package; defaults to the data migration's own package, and can target a *different* package for cross-package deps. Resolved via `DataMigration.afterPackage()`.

```go
rockhopper.WithDataMigrationName("backfill_users", "orders") // name + package
rockhopper.After(20240116231445)                             // schema version in this migration's package
rockhopper.After(20240116231445, "core")                     // ... in the "core" package instead
```

## 2. Batch retries, safe checkpoints, error modernization

- **Backoff retries** — a failed batch is retried with exponential backoff up to `BackoffLimit` times (default `3`) before the migration is marked failed. New `WithBackoffLimit(n)` and `WithBackoffDelay(d)` options; a negative limit disables retries. Self-contained in the runner — no schema/dialect changes.
- **Empty-checkpoint safety** — a run that finds an empty stored checkpoint (e.g. a prior attempt failed before `Plan` persisted anything) re-invokes `Plan` before batching, so `Batch` never receives an empty checkpoint unless `Plan` returns one. Avoids `json.Unmarshal` "unexpected end of JSON input" in application code.
- **`errors.Wrapf` → `fmt.Errorf` + `%w`** in the runner (Wrapf is deprecated).

## Breaking change

`AddDataMigration` no longer derives the package from the caller's function name; it defaults to `"main"`. Anyone on v2.2.0 relying on the derived name should set it via `WithDataMigrationName(name, pkg)` or `AddNamedDataMigration`. Suggest landing as **v2.3.0**.

## Tests

- Package resolution (default / explicit / cross-package gate).
- `After` / `WithDataMigrationName` option behavior.
- Backoff: retry-then-succeed, limit-exhausted, retries-disabled; `backoffLimit`/`backoffDelay` helpers.
- Re-plan on empty checkpoint.
- Full suite green (`go test ./...`), `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)