### PR TITLE
feat(datamigration): batch retries, safe checkpoints, structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,21 @@ checkpoint), then loops `Batch` — committing each batch with its checkpoint an
 pausing for `Throttle` — until the migrator reports `done`. Cancel the `ctx` to
 stop between batches; the next run picks up where it left off.
 
+If a batch returns an error, the runner retries it after an exponential backoff
+pause, up to `BackoffLimit` times (default `3`), before marking the migration
+failed and returning the error. Tune it per migration:
+
+```go
+rockhopper.WithBackoffLimit(5),                  // retry a failing batch up to 5 times
+rockhopper.WithBackoffDelay(2*time.Second),      // base pause, doubled each retry
+// rockhopper.WithBackoffLimit(-1)               // disable retries (fail on first error)
+```
+
+A run that finds an empty stored checkpoint (e.g. a prior attempt failed before
+`Plan` persisted anything) re-invokes `Plan` before batching, so `Batch` never
+receives an empty checkpoint unless `Plan` itself returns one — a JSON
+checkpoint can be `json.Unmarshal`ed without guarding against an empty payload.
+
 ## Environment Variables
 
 You can override config file values with environment variables:

--- a/README.md
+++ b/README.md
@@ -932,6 +932,14 @@ A run that finds an empty stored checkpoint (e.g. a prior attempt failed before
 receives an empty checkpoint unless `Plan` itself returns one — a JSON
 checkpoint can be `json.Unmarshal`ed without guarding against an empty payload.
 
+Every data-migration log line carries the structured field
+`component=data_migrator` along with `package` and `version`, so you can filter
+the data migrator's phase/progress output apart from the schema runner's. Phase
+transitions (planning, resuming, completed, skipped, lease held/lost, retries)
+log at `info`/`warn`; per-batch progress (`batch`, `checkpoint_bytes`, `done`)
+logs at `debug` — raise the logrus level to `debug` to follow batch-by-batch
+progress on a long backfill.
+
 ## Environment Variables
 
 You can override config file values with environment variables:

--- a/datamigration.go
+++ b/datamigration.go
@@ -37,6 +37,20 @@ const (
 // comfortably exceed a single batch's duration plus its throttle pause.
 const DefaultLeaseTTL = 30 * time.Second
 
+// DefaultBackoffLimit is the number of times a failed batch is retried before
+// the data migration gives up and is marked failed. It is used when a data
+// migration does not set BackoffLimit.
+const DefaultBackoffLimit = 3
+
+// DefaultBackoffDelay is the base pause before the first retry of a failed
+// batch. It doubles on each subsequent attempt, capped at maxBackoffDelay. It
+// is used when a data migration does not set BackoffDelay.
+const DefaultBackoffDelay = 1 * time.Second
+
+// maxBackoffDelay caps the exponential retry pause so a large BackoffLimit
+// cannot produce an unbounded (or overflowing) delay.
+const maxBackoffDelay = 5 * time.Minute
+
 var (
 	// ErrLeaseHeld is returned when another live process holds the lease for a
 	// data migration. Callers running a single driver (e.g. a Kubernetes Job
@@ -120,7 +134,12 @@ type DataMigrator interface {
 	// advanced checkpoint and whether the migration is complete. exec is bound
 	// to the transaction that persists the returned checkpoint, so Batch must
 	// not commit, roll back or sleep. Batches should be idempotent so that an
-	// interrupted batch can safely be retried on resume.
+	// interrupted batch can safely be retried on resume (the runner also retries
+	// a failed batch up to BackoffLimit times before giving up).
+	//
+	// cp is never empty unless Plan returned an empty checkpoint: a run that
+	// finds an empty stored checkpoint re-invokes Plan first, so json.Unmarshal
+	// on cp will not fail on an empty payload as long as Plan returns valid JSON.
 	Batch(ctx context.Context, exec BatchExecutor, cp Checkpoint) (next Checkpoint, done bool, err error)
 }
 
@@ -161,6 +180,48 @@ type DataMigration struct {
 	// may steal it. It is renewed on every batch commit. Zero means
 	// DefaultLeaseTTL. It must exceed a single batch's duration plus Throttle.
 	LeaseTTL time.Duration
+
+	// BackoffLimit is the number of times a failed batch is retried (with an
+	// exponential backoff pause) within a single run before the migration gives
+	// up and is marked failed. Zero means DefaultBackoffLimit; a negative value
+	// disables retries (the batch fails on its first error).
+	BackoffLimit int
+
+	// BackoffDelay is the base pause before the first retry; it doubles on each
+	// subsequent attempt, capped internally. Zero means DefaultBackoffDelay.
+	BackoffDelay time.Duration
+}
+
+// backoffLimit returns the configured retry count, applying DefaultBackoffLimit
+// for the zero value and clamping a negative value to zero (no retries).
+func (dm *DataMigration) backoffLimit() int {
+	if dm.BackoffLimit == 0 {
+		return DefaultBackoffLimit
+	}
+
+	if dm.BackoffLimit < 0 {
+		return 0
+	}
+
+	return dm.BackoffLimit
+}
+
+// backoffDelay returns the pause before the given 1-based retry attempt: the
+// base delay doubled (attempt-1) times, capped at maxBackoffDelay.
+func (dm *DataMigration) backoffDelay(attempt int) time.Duration {
+	d := dm.BackoffDelay
+	if d <= 0 {
+		d = DefaultBackoffDelay
+	}
+
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if d >= maxBackoffDelay {
+			return maxBackoffDelay
+		}
+	}
+
+	return d
 }
 
 // afterPackage returns the package that the After schema version is looked up
@@ -235,6 +296,22 @@ func WithDataMigrationName(name string, packageName ...string) DataMigrationOpti
 func WithLeaseTTL(d time.Duration) DataMigrationOption {
 	return func(dm *DataMigration) {
 		dm.LeaseTTL = d
+	}
+}
+
+// WithBackoffLimit sets how many times a failed batch is retried within a single
+// run before the migration gives up. A negative value disables retries.
+func WithBackoffLimit(n int) DataMigrationOption {
+	return func(dm *DataMigration) {
+		dm.BackoffLimit = n
+	}
+}
+
+// WithBackoffDelay sets the base pause before the first retry of a failed batch;
+// it doubles on each subsequent attempt, capped internally.
+func WithBackoffDelay(d time.Duration) DataMigrationOption {
+	return func(dm *DataMigration) {
+		dm.BackoffDelay = d
 	}
 }
 

--- a/datamigration.go
+++ b/datamigration.go
@@ -20,6 +20,11 @@ import (
 // table (TableName) so the schema runner's done/not-done semantics stay intact.
 const DataMigrationTableName = "rockhopper_data_migrations"
 
+// dataMigratorComponent is the value of the "component" log field stamped on
+// every data-migration log line, so operators can filter the data-migrator's
+// output apart from the schema runner's.
+const dataMigratorComponent = "data_migrator"
+
 // Data migration status values stored in the status column.
 const (
 	// DataMigrationPending means the migration has a row but no batch has run yet.
@@ -243,6 +248,23 @@ func (dm *DataMigration) leaseTTL() time.Duration {
 	}
 
 	return DefaultLeaseTTL
+}
+
+// logEntry returns a logrus entry pre-populated with the data-migrator
+// component tag and this migration's identity, so every phase/progress line
+// carries consistent, filterable structured fields.
+func (dm *DataMigration) logEntry() *log.Entry {
+	fields := log.Fields{
+		"component": dataMigratorComponent,
+		"package":   dm.Package,
+		"version":   dm.Version,
+	}
+
+	if dm.Name != "" {
+		fields["name"] = dm.Name
+	}
+
+	return log.WithFields(fields)
 }
 
 func (dm *DataMigration) String() string {

--- a/datamigration_run.go
+++ b/datamigration_run.go
@@ -196,6 +196,9 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 		return err
 	}
 
+	logger := dm.logEntry()
+	logger.Debug("starting data migration run")
+
 	// dependency gate: the mapped schema migration must be applied first.
 	if dm.After > 0 {
 		afterPkg := dm.afterPackage()
@@ -205,8 +208,13 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 		}
 
 		if !applied {
+			logger.WithFields(log.Fields{"after_package": afterPkg, "after_version": dm.After}).
+				Warn("data migration blocked: schema dependency not applied yet")
 			return fmt.Errorf("data migration %s depends on schema version %s:%d which is not applied yet", dm, afterPkg, dm.After)
 		}
+
+		logger.WithFields(log.Fields{"after_package": afterPkg, "after_version": dm.After}).
+			Debug("schema dependency satisfied")
 	}
 
 	status, _, found, err := db.loadDataMigrationState(ctx, dm.Package, dm.Version)
@@ -215,7 +223,7 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 	}
 
 	if found && status == DataMigrationCompleted {
-		log.Infof("data migration %s already completed, skipping", dm)
+		logger.Info("data migration already completed, skipping")
 		return nil
 	}
 
@@ -233,7 +241,7 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 			}
 
 			if status == DataMigrationCompleted {
-				log.Infof("data migration %s already completed, skipping", dm)
+				logger.Info("data migration already completed, skipping")
 				return nil
 			}
 		}
@@ -248,9 +256,11 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 	}
 
 	if !acquired {
-		log.Infof("data migration %s is driven by another process, skipping", dm)
+		logger.Info("data migration is driven by another process, skipping")
 		return ErrLeaseHeld
 	}
+
+	logger.WithFields(log.Fields{"lease_owner": owner, "lease_ttl": ttl}).Debug("data migration lease acquired")
 
 	// we hold the lease; reload the authoritative status and checkpoint (a
 	// stolen lease resumes from the previous owner's last committed batch).
@@ -260,7 +270,7 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 	}
 
 	if status == DataMigrationCompleted {
-		log.Infof("data migration %s already completed, skipping", dm)
+		logger.Info("data migration already completed, skipping")
 		return db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationCompleted)
 	}
 
@@ -270,22 +280,28 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 		// so repeating it is safe, and it guarantees Batch never receives an
 		// empty checkpoint unless the migrator's own Plan returns one — sparing
 		// callers from json.Unmarshal failing on an empty payload.
+		logger.Info("planning data migration")
 		cp, err = dm.Migrator.Plan(ctx, db.DB)
 		if err != nil {
 			if rerr := db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationFailed); rerr != nil {
-				log.WithError(rerr).Warnf("failed to release lease for data migration %s after plan error", dm)
+				logger.WithError(rerr).Warn("failed to release lease after plan error")
 			}
 
 			return fmt.Errorf("data migration %s: plan failed: %w", dm, err)
 		}
+
+		logger.WithField("checkpoint_bytes", len(cp)).Debug("data migration planned")
 	} else {
-		log.Infof("resuming data migration %s from checkpoint", dm)
+		logger.WithField("checkpoint_bytes", len(cp)).Info("resuming data migration from stored checkpoint")
 	}
 
 	// attempts counts consecutive batch failures; it resets whenever a batch
 	// commits successfully, so the backoff limit bounds retries of a stuck
-	// batch, not transient failures spread across a long migration.
+	// batch, not transient failures spread across a long migration. batches
+	// counts committed batches for progress logging.
 	attempts := 0
+	batches := 0
+	startedAt := time.Now()
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -295,6 +311,7 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 		if err != nil {
 			if errors.Is(err, ErrLeaseLost) {
 				// another process owns the migration now; leave its state alone.
+				logger.WithField("batches", batches).Warn("data migration lease lost to another process")
 				return err
 			}
 
@@ -302,7 +319,8 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 			attempts++
 			if attempts <= limit {
 				delay := dm.backoffDelay(attempts)
-				log.WithError(err).Warnf("data migration %s: batch failed (attempt %d/%d), retrying in %s", dm, attempts, limit, delay)
+				logger.WithError(err).WithFields(log.Fields{"attempt": attempts, "limit": limit, "retry_in": delay}).
+					Warn("data migration batch failed, retrying after backoff")
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
@@ -313,17 +331,24 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 			}
 
 			if rerr := db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationFailed); rerr != nil {
-				log.WithError(rerr).Warnf("failed to mark data migration %s as failed", dm)
+				logger.WithError(rerr).Warn("failed to mark data migration as failed")
 			}
 
+			logger.WithError(err).WithFields(log.Fields{"attempts": attempts, "batches": batches}).
+				Error("data migration failed: batch retries exhausted")
 			return fmt.Errorf("data migration %s: batch failed after %d attempt(s): %w", dm, attempts, err)
 		}
 
 		attempts = 0
+		batches++
 		cp = next
 
+		logger.WithFields(log.Fields{"batch": batches, "checkpoint_bytes": len(cp), "done": done}).
+			Debug("data migration batch committed")
+
 		if done {
-			log.Infof("data migration %s completed", dm)
+			logger.WithFields(log.Fields{"batches": batches, "elapsed": time.Since(startedAt)}).
+				Info("data migration completed")
 			return db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationCompleted)
 		}
 
@@ -399,6 +424,9 @@ func (db *DB) runDataBatch(ctx context.Context, dm *DataMigration, owner string,
 
 // RunDataMigrations runs the given data migrations in version order.
 func RunDataMigrations(ctx context.Context, db *DB, dms []*DataMigration) error {
+	log.WithFields(log.Fields{"component": dataMigratorComponent, "count": len(dms)}).
+		Debug("running data migrations")
+
 	for _, dm := range dms {
 		if err := RunDataMigration(ctx, db, dm); err != nil {
 			return err

--- a/datamigration_run.go
+++ b/datamigration_run.go
@@ -264,20 +264,28 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 		return db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationCompleted)
 	}
 
-	if status == DataMigrationPending {
-		// first run: compute the starting checkpoint.
+	if status == DataMigrationPending || len(cp) == 0 {
+		// First run, or a prior attempt failed before persisting any progress:
+		// (re)compute the starting checkpoint. Plan is read-only and idempotent,
+		// so repeating it is safe, and it guarantees Batch never receives an
+		// empty checkpoint unless the migrator's own Plan returns one — sparing
+		// callers from json.Unmarshal failing on an empty payload.
 		cp, err = dm.Migrator.Plan(ctx, db.DB)
 		if err != nil {
 			if rerr := db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationFailed); rerr != nil {
 				log.WithError(rerr).Warnf("failed to release lease for data migration %s after plan error", dm)
 			}
 
-			return errors.Wrapf(err, "data migration %s: plan failed", dm)
+			return fmt.Errorf("data migration %s: plan failed: %w", dm, err)
 		}
 	} else {
 		log.Infof("resuming data migration %s from checkpoint", dm)
 	}
 
+	// attempts counts consecutive batch failures; it resets whenever a batch
+	// commits successfully, so the backoff limit bounds retries of a stuck
+	// batch, not transient failures spread across a long migration.
+	attempts := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -290,13 +298,28 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 				return err
 			}
 
+			limit := dm.backoffLimit()
+			attempts++
+			if attempts <= limit {
+				delay := dm.backoffDelay(attempts)
+				log.WithError(err).Warnf("data migration %s: batch failed (attempt %d/%d), retrying in %s", dm, attempts, limit, delay)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(delay):
+				}
+
+				continue
+			}
+
 			if rerr := db.releaseDataMigrationLease(ctx, dm, owner, DataMigrationFailed); rerr != nil {
 				log.WithError(rerr).Warnf("failed to mark data migration %s as failed", dm)
 			}
 
-			return errors.Wrapf(err, "data migration %s: batch failed", dm)
+			return fmt.Errorf("data migration %s: batch failed after %d attempt(s): %w", dm, attempts, err)
 		}
 
+		attempts = 0
 		cp = next
 
 		if done {

--- a/datamigration_test.go
+++ b/datamigration_test.go
@@ -364,6 +364,132 @@ func TestRunDataMigration_DependencyGate(t *testing.T) {
 	assert.Equal(t, 5, countMigrated(t, db))
 }
 
+// flakyMigrator fails its first failFirst Batch calls, then reports done. Its
+// checkpoint is non-empty so it does not depend on the empty-checkpoint replan.
+type flakyMigrator struct {
+	failFirst int
+
+	planCalls  int
+	batchCalls int
+}
+
+func (m *flakyMigrator) Plan(ctx context.Context, q Queryer) (Checkpoint, error) {
+	m.planCalls++
+	return Checkpoint(`{"started":true}`), nil
+}
+
+func (m *flakyMigrator) Batch(ctx context.Context, exec BatchExecutor, cp Checkpoint) (Checkpoint, bool, error) {
+	m.batchCalls++
+	if m.batchCalls <= m.failFirst {
+		return nil, false, fmt.Errorf("transient failure on batch %d", m.batchCalls)
+	}
+
+	return cp, true, nil
+}
+
+func TestBackoffLimit(t *testing.T) {
+	assert.Equal(t, DefaultBackoffLimit, (&DataMigration{}).backoffLimit(), "zero falls back to the default")
+	assert.Equal(t, 0, (&DataMigration{BackoffLimit: -1}).backoffLimit(), "negative disables retries")
+	assert.Equal(t, 5, (&DataMigration{BackoffLimit: 5}).backoffLimit())
+}
+
+func TestBackoffDelay(t *testing.T) {
+	dm := &DataMigration{BackoffDelay: 10 * time.Millisecond}
+	assert.Equal(t, 10*time.Millisecond, dm.backoffDelay(1))
+	assert.Equal(t, 20*time.Millisecond, dm.backoffDelay(2))
+	assert.Equal(t, 40*time.Millisecond, dm.backoffDelay(3))
+
+	// the zero value uses the default base.
+	assert.Equal(t, DefaultBackoffDelay, (&DataMigration{}).backoffDelay(1))
+
+	// growth is capped.
+	assert.Equal(t, maxBackoffDelay, (&DataMigration{BackoffDelay: time.Minute}).backoffDelay(20))
+}
+
+func TestRunDataMigration_BackoffRetrySucceeds(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	require.NoError(t, db.Touch(ctx))
+
+	mig := &flakyMigrator{failFirst: 2}
+	dm := &DataMigration{
+		Package:      DefaultPackageName,
+		Version:      1700000000000007,
+		Migrator:     mig,
+		BackoffLimit: 3,
+		BackoffDelay: time.Millisecond,
+	}
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 3, mig.batchCalls, "2 failed attempts then a successful one")
+
+	_, _, status := leaseState(t, db, dm)
+	assert.Equal(t, DataMigrationCompleted, status)
+}
+
+func TestRunDataMigration_BackoffLimitExhausted(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	require.NoError(t, db.Touch(ctx))
+
+	mig := &flakyMigrator{failFirst: 100} // never recovers
+	dm := &DataMigration{
+		Package:      DefaultPackageName,
+		Version:      1700000000000008,
+		Migrator:     mig,
+		BackoffLimit: 2,
+		BackoffDelay: time.Millisecond,
+	}
+
+	err := RunDataMigration(ctx, db, dm)
+	require.Error(t, err)
+	assert.Equal(t, 3, mig.batchCalls, "1 initial attempt + 2 retries")
+
+	_, _, status := leaseState(t, db, dm)
+	assert.Equal(t, DataMigrationFailed, status)
+}
+
+func TestRunDataMigration_BackoffDisabled(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	require.NoError(t, db.Touch(ctx))
+
+	mig := &flakyMigrator{failFirst: 100}
+	dm := &DataMigration{
+		Package:      DefaultPackageName,
+		Version:      1700000000000009,
+		Migrator:     mig,
+		BackoffLimit: -1, // no retries
+	}
+
+	require.Error(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 1, mig.batchCalls, "fails on the first error with no retry")
+}
+
+// TestRunDataMigration_ReplansOnEmptyCheckpoint verifies that a migration left
+// in a non-pending state with an empty checkpoint is re-planned, so the migrator
+// never receives an empty checkpoint it would fail to json.Unmarshal.
+func TestRunDataMigration_ReplansOnEmptyCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 5)
+	require.NoError(t, db.Touch(ctx))
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{
+		Package:  DefaultPackageName,
+		Version:  1700000000000010,
+		Migrator: mig,
+	}
+
+	// a prior attempt failed before persisting any checkpoint.
+	seedDataMigrationRow(t, db, dm, DataMigrationFailed, "", "", 0)
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+	assert.Equal(t, 1, mig.planCalls, "Plan re-run because the stored checkpoint was empty")
+	assert.Equal(t, 5, countMigrated(t, db))
+}
+
 func TestAfterOption_TargetPackage(t *testing.T) {
 	t.Run("defaults to the data migration's own package", func(t *testing.T) {
 		dm := &DataMigration{Package: "orders"}


### PR DESCRIPTION
Follow-up to #39 (which merged the package-aware dependency change). Two commits, both scoped to the data migrator.

## 1. Batch retries, safe checkpoints, error modernization

- **Backoff retries** — a failed batch is retried with exponential backoff up to `BackoffLimit` times (default `3`) before the migration is marked failed. New `WithBackoffLimit(n)` and `WithBackoffDelay(d)` options; a negative limit disables retries. Self-contained in the runner — no schema/dialect changes.
- **Empty-checkpoint safety** — a run that finds an empty stored checkpoint (e.g. a prior attempt failed before `Plan` persisted anything) re-invokes `Plan` before batching, so `Batch` never receives an empty checkpoint unless `Plan` returns one. Avoids `json.Unmarshal` "unexpected end of JSON input" in application code. The resume-vs-replan boundary keys off the checkpoint (`len(cp) == 0`), not the `failed` status, so a batch that failed partway through a large backfill still resumes from its last committed cursor instead of restarting.
- **`errors.Wrapf` → `fmt.Errorf` + `%w`** in the runner (Wrapf is deprecated).

```go
rockhopper.WithBackoffLimit(5),              // retry a failing batch up to 5 times
rockhopper.WithBackoffDelay(2*time.Second),  // base pause, doubled each retry
// rockhopper.WithBackoffLimit(-1)           // disable retries (fail on first error)
```

## 2. Structured logrus logging

Every data-migration log line carries `component=data_migrator` plus `package`/`version` (and `name` when set) via `DataMigration.logEntry()`.

- **info/warn** — phase transitions: planning, resuming (with `checkpoint_bytes`), completed (with `batches` + `elapsed`), skipped, lease acquired/held/lost, dependency satisfied/blocked, retries.
- **debug** — per-batch progress (`batch`, `checkpoint_bytes`, `done`); raise the logrus level to follow a long backfill batch-by-batch.

```
level=info msg="data migration completed" batches=1 component=data_migrator elapsed=3.65ms package=main version=1700000000000007
level=warning msg="data migration batch failed, retrying after backoff" attempt=1 component=data_migrator limit=3 retry_in=1ms ...
```

## Tests

- Backoff: retry-then-succeed, limit-exhausted, retries-disabled; `backoffLimit`/`backoffDelay` helpers.
- Re-plan on empty checkpoint.
- Full suite green (`go test ./...`), `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)