### PR TITLE
feat(datamigration): wait out stale leases so a new pod can take over

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,6 +932,32 @@ A run that finds an empty stored checkpoint (e.g. a prior attempt failed before
 receives an empty checkpoint unless `Plan` itself returns one — a JSON
 checkpoint can be `json.Unmarshal`ed without guarding against an empty payload.
 
+### Leases and crash recovery
+
+Exactly one process drives a migration at a time, enforced by a lease in the
+state table. The lease carries an expiry (`LeaseTTL`, default `30s`) that is
+renewed on every batch commit, so if the driving process crashes, its lease
+becomes acquirable `LeaseTTL` after its last committed batch.
+
+When another process holds the lease, a starting process retries acquisition for
+up to `LeaseWait` (default `2 × LeaseTTL`) before giving up with `ErrLeaseHeld`.
+That window is deliberately longer than the TTL: a **crashed** holder's lease
+expires within it and the new process takes over the work, while a **live**
+holder keeps renewing and is never reclaimed — so the new process waits out the
+window and correctly skips. Without this wait a process that starts within the
+TTL of a crash would see the stale lease, log *"driven by another process,
+skipping"*, and stall.
+
+```go
+rockhopper.WithLeaseTTL(2*time.Minute),  // raise if a single batch can take longer than the default 30s
+rockhopper.WithLeaseWait(5*time.Minute), // how long to wait out a held/stale lease (default 2×TTL)
+// rockhopper.WithLeaseWait(-1)          // disable waiting — report ErrLeaseHeld immediately
+```
+
+Set `LeaseTTL` comfortably above one batch's duration plus its `Throttle`;
+otherwise a live process's lease can expire mid-batch and be stolen (surfaced as
+`ErrLeaseLost`, with the in-flight batch rolled back).
+
 Every data-migration log line carries the structured field
 `component=data_migrator` along with `package` and `version`, so you can filter
 the data migrator's phase/progress output apart from the schema runner's. Phase

--- a/datamigration.go
+++ b/datamigration.go
@@ -186,6 +186,15 @@ type DataMigration struct {
 	// DefaultLeaseTTL. It must exceed a single batch's duration plus Throttle.
 	LeaseTTL time.Duration
 
+	// LeaseWait is how long to keep retrying lease acquisition when another
+	// process holds it, before giving up with ErrLeaseHeld. It lets a freshly
+	// started process wait out a stale lease left by a crashed predecessor
+	// (which becomes acquirable LeaseTTL after that predecessor's last batch).
+	// Zero means a default of 2*LeaseTTL — long enough that a dead holder's
+	// lease is guaranteed to expire while a live holder keeps renewing it. A
+	// negative value disables waiting (acquisition is attempted once).
+	LeaseWait time.Duration
+
 	// BackoffLimit is the number of times a failed batch is retried (with an
 	// exponential backoff pause) within a single run before the migration gives
 	// up and is marked failed. Zero means DefaultBackoffLimit; a negative value
@@ -248,6 +257,37 @@ func (dm *DataMigration) leaseTTL() time.Duration {
 	}
 
 	return DefaultLeaseTTL
+}
+
+// leaseWait returns how long to keep retrying lease acquisition, applying the
+// 2*LeaseTTL default for the zero value and clamping a negative value to zero
+// (acquire once, no waiting).
+func (dm *DataMigration) leaseWait() time.Duration {
+	if dm.LeaseWait < 0 {
+		return 0
+	}
+
+	if dm.LeaseWait == 0 {
+		return 2 * dm.leaseTTL()
+	}
+
+	return dm.LeaseWait
+}
+
+// leasePollInterval is the pause between lease-acquisition retries while
+// waiting. It is a quarter of the TTL, clamped to [1s, 5s], so a stale lease is
+// noticed promptly without hammering the database.
+func (dm *DataMigration) leasePollInterval() time.Duration {
+	iv := dm.leaseTTL() / 4
+	if iv < time.Second {
+		return time.Second
+	}
+
+	if iv > 5*time.Second {
+		return 5 * time.Second
+	}
+
+	return iv
 }
 
 // logEntry returns a logrus entry pre-populated with the data-migrator
@@ -318,6 +358,15 @@ func WithDataMigrationName(name string, packageName ...string) DataMigrationOpti
 func WithLeaseTTL(d time.Duration) DataMigrationOption {
 	return func(dm *DataMigration) {
 		dm.LeaseTTL = d
+	}
+}
+
+// WithLeaseWait sets how long to keep retrying lease acquisition when another
+// process holds the lease, before giving up with ErrLeaseHeld. Zero uses the
+// default of 2*LeaseTTL; a negative value disables waiting (acquire once).
+func WithLeaseWait(d time.Duration) DataMigrationOption {
+	return func(dm *DataMigration) {
+		dm.LeaseWait = d
 	}
 }
 

--- a/datamigration_run.go
+++ b/datamigration_run.go
@@ -130,6 +130,60 @@ func (db *DB) acquireDataMigrationLease(ctx context.Context, dm *DataMigration, 
 	return affected == 1, nil
 }
 
+// acquireDataMigrationLeaseWaiting claims the lease, retrying for up to
+// dm.leaseWait() when another process holds it. A crashed predecessor leaves a
+// lease that becomes acquirable once it expires (LeaseTTL after its last batch),
+// so waiting longer than the TTL lets a fresh process take over a dead holder's
+// work while still correctly yielding to a live holder, which keeps renewing and
+// is never reclaimed within the window. It returns false (no error) if the lease
+// is still held when the wait elapses.
+func (db *DB) acquireDataMigrationLeaseWaiting(ctx context.Context, dm *DataMigration, owner string, ttl time.Duration, logger *log.Entry) (bool, error) {
+	acquired, err := db.acquireDataMigrationLease(ctx, dm, owner, ttl)
+	if err != nil || acquired {
+		return acquired, err
+	}
+
+	wait := dm.leaseWait()
+	if wait <= 0 {
+		return false, nil
+	}
+
+	interval := dm.leasePollInterval()
+	start := time.Now()
+	deadline := start.Add(wait)
+	logger.WithFields(log.Fields{"wait": wait, "poll_interval": interval}).
+		Info("data migration lease held by another process, waiting for it to be released or to expire")
+
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false, nil
+		}
+
+		sleep := interval
+		if sleep > remaining {
+			sleep = remaining
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(sleep):
+		}
+
+		acquired, err := db.acquireDataMigrationLease(ctx, dm, owner, ttl)
+		if err != nil {
+			return false, err
+		}
+
+		if acquired {
+			logger.WithField("waited", time.Since(start)).
+				Info("data migration lease acquired after waiting (took over a stale lease)")
+			return true, nil
+		}
+	}
+}
+
 // releaseDataMigrationLease sets a terminal status and clears the lease, guarded
 // by ownership (a process that no longer holds the lease is a no-op).
 func (db *DB) releaseDataMigrationLease(ctx context.Context, dm *DataMigration, owner, status string) error {
@@ -250,7 +304,7 @@ func RunDataMigration(ctx context.Context, db *DB, dm *DataMigration) error {
 	owner := leaseOwner()
 	ttl := dm.leaseTTL()
 
-	acquired, err := db.acquireDataMigrationLease(ctx, dm, owner, ttl)
+	acquired, err := db.acquireDataMigrationLeaseWaiting(ctx, dm, owner, ttl, logger)
 	if err != nil {
 		return err
 	}

--- a/datamigration_test.go
+++ b/datamigration_test.go
@@ -221,7 +221,8 @@ func TestRunDataMigration_LeaseHeldByAnother(t *testing.T) {
 	seedUsers(t, db, 25)
 
 	mig := &backfillMigrator{table: "users", batchSize: 10}
-	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000021, Migrator: mig}
+	// LeaseWait < 0 disables waiting so a held lease is reported immediately.
+	dm := &DataMigration{Package: DefaultPackageName, Version: 1700000000000021, Migrator: mig, LeaseWait: -1}
 
 	// another process holds a live lease.
 	future := time.Now().Add(1 * time.Hour).Unix()
@@ -260,6 +261,109 @@ func TestRunDataMigration_StealsExpiredLease(t *testing.T) {
 	owner, _, status := leaseState(t, db, dm)
 	assert.Equal(t, DataMigrationCompleted, status)
 	assert.False(t, owner.Valid)
+}
+
+func TestLeaseWait(t *testing.T) {
+	// zero -> 2 * the effective TTL (default TTL here).
+	assert.Equal(t, 2*DefaultLeaseTTL, (&DataMigration{}).leaseWait())
+	// zero with a custom TTL -> 2 * that TTL.
+	assert.Equal(t, 20*time.Second, (&DataMigration{LeaseTTL: 10 * time.Second}).leaseWait())
+	// negative disables waiting.
+	assert.Equal(t, time.Duration(0), (&DataMigration{LeaseWait: -1}).leaseWait())
+	// explicit value is used as-is.
+	assert.Equal(t, 90*time.Second, (&DataMigration{LeaseWait: 90 * time.Second}).leaseWait())
+}
+
+func TestLeasePollInterval(t *testing.T) {
+	assert.Equal(t, time.Second, (&DataMigration{LeaseTTL: 2 * time.Second}).leasePollInterval(), "TTL/4 clamped up to 1s floor")
+	assert.Equal(t, 3*time.Second, (&DataMigration{LeaseTTL: 12 * time.Second}).leasePollInterval(), "TTL/4 within range")
+	assert.Equal(t, 5*time.Second, (&DataMigration{LeaseTTL: time.Minute}).leasePollInterval(), "TTL/4 clamped to 5s ceiling")
+}
+
+// TestRunDataMigration_WaitsForStaleLeaseToExpire covers the crashed-predecessor
+// case: a held lease that expires shortly after the new process starts. The new
+// process must wait it out and take over rather than skipping immediately.
+func TestRunDataMigration_WaitsForStaleLeaseToExpire(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{
+		Package:   DefaultPackageName,
+		Version:   1700000000000030,
+		Migrator:  mig,
+		LeaseTTL:  4 * time.Second, // -> 1s poll interval
+		LeaseWait: 10 * time.Second,
+	}
+
+	// a crashed predecessor's lease expires ~1s from now (integer-second
+	// granularity means it becomes acquirable within a couple of polls).
+	expiresSoon := time.Now().Add(1 * time.Second).Unix()
+	seedDataMigrationRow(t, db, dm, DataMigrationRunning, mustCursor(t, 0, 25), "dead-pod", expiresSoon)
+
+	require.NoError(t, RunDataMigration(ctx, db, dm))
+
+	assert.Equal(t, 25, countMigrated(t, db))
+	assert.Equal(t, 0, mig.planCalls, "running status with a checkpoint resumes rather than re-planning")
+
+	owner, _, status := leaseState(t, db, dm)
+	assert.Equal(t, DataMigrationCompleted, status)
+	assert.False(t, owner.Valid)
+}
+
+// TestRunDataMigration_WaitTimesOutWhileLeaseHeld covers a live holder: the lease
+// never expires within the wait window, so the new process correctly gives up
+// with ErrLeaseHeld instead of double-running.
+func TestRunDataMigration_WaitTimesOutWhileLeaseHeld(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{
+		Package:   DefaultPackageName,
+		Version:   1700000000000031,
+		Migrator:  mig,
+		LeaseTTL:  4 * time.Second,
+		LeaseWait: 2 * time.Second, // shorter than the lease's remaining life
+	}
+
+	future := time.Now().Add(1 * time.Hour).Unix()
+	seedDataMigrationRow(t, db, dm, DataMigrationRunning, mustCursor(t, 0, 25), "live-pod", future)
+
+	start := time.Now()
+	err := RunDataMigration(ctx, db, dm)
+	assert.ErrorIs(t, err, ErrLeaseHeld)
+	assert.GreaterOrEqual(t, time.Since(start), 2*time.Second, "should have waited the full window before giving up")
+
+	assert.Equal(t, 0, countMigrated(t, db))
+	owner, _, _ := leaseState(t, db, dm)
+	assert.Equal(t, "live-pod", owner.String, "the live holder's lease is left untouched")
+}
+
+// TestRunDataMigration_WaitDisabledSkipsImmediately covers LeaseWait < 0: a held
+// lease is reported without waiting.
+func TestRunDataMigration_WaitDisabledSkipsImmediately(t *testing.T) {
+	ctx := context.Background()
+	db := openDataMigrationTestDB(t)
+	seedUsers(t, db, 25)
+
+	mig := &backfillMigrator{table: "users", batchSize: 10}
+	dm := &DataMigration{
+		Package:   DefaultPackageName,
+		Version:   1700000000000032,
+		Migrator:  mig,
+		LeaseWait: -1,
+	}
+
+	future := time.Now().Add(1 * time.Hour).Unix()
+	seedDataMigrationRow(t, db, dm, DataMigrationRunning, mustCursor(t, 0, 25), "live-pod", future)
+
+	start := time.Now()
+	err := RunDataMigration(ctx, db, dm)
+	assert.ErrorIs(t, err, ErrLeaseHeld)
+	assert.Less(t, time.Since(start), time.Second, "must not wait when waiting is disabled")
 }
 
 // leaseStealingMigrator mutates the lease owner from inside a batch to simulate


### PR DESCRIPTION
## Problem

After a pod crashed without releasing its lease, a freshly started pod logged:

> data migration is driven by another process, skipping

…and stalled. The lease *would* have expired seconds later (it carries a `LeaseTTL`, renewed per batch), but `RunDataMigration` attempted acquisition **exactly once** and gave up immediately with `ErrLeaseHeld`. A pod that started within the TTL window of a crash never came back to find the lease had since expired.

## Fix

Retry lease acquisition for up to **`LeaseWait` (default `2 × LeaseTTL`)** before giving up. The window is deliberately longer than the TTL, which is what makes it correct in both cases:

- **Crashed holder** → its lease expires within the window; the next poll acquires it and the new process takes over (resuming from the last committed checkpoint). ✅
- **Live holder** → keeps renewing, so the lease never expires; the new process waits the full window and *correctly* returns `ErrLeaseHeld`. ✅ No double-run.

Polling is `LeaseTTL/4`, clamped to `[1s, 5s]`. The common path (uncontended lease) is unaffected — the first acquire succeeds, no waiting.

```go
rockhopper.WithLeaseTTL(2*time.Minute),  // raise if a batch can exceed the default 30s
rockhopper.WithLeaseWait(5*time.Minute), // how long to wait out a held/stale lease (default 2×TTL)
// rockhopper.WithLeaseWait(-1)          // disable waiting (report ErrLeaseHeld immediately)
```

No schema or dialect changes — the expiry mechanism (`lease_expires_at`, renewed per batch) already existed; this only changes the acquire side.

## Tests

- `leaseWait` / `leasePollInterval` helpers (defaults, clamps, disable).
- Takeover after a stale lease expires mid-wait (~2s).
- Time-out + `ErrLeaseHeld` while a live holder keeps the lease (~2s); holder's lease left untouched.
- `LeaseWait < 0` skips immediately (<1s).
- Updated `TestRunDataMigration_LeaseHeldByAnother` to set `LeaseWait: -1` (it would otherwise block for the new 60s default).
- Full suite green, `go vet` clean.

> [!NOTE]
> Stacked on #40 (base = `c9s/data-migration-backoff-and-logging`), since it builds on that branch's logging entry and acquire path. Retarget to `main` once #40 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)