### PR TITLE
fix(skills): quote argument-hint so Copilot CLI 1.0.65 parses it as string

### DIFF
--- a/.claude/skills/apply-migrations/SKILL.md
+++ b/.claude/skills/apply-migrations/SKILL.md
@@ -2,7 +2,7 @@
 name: apply-migrations
 description: Apply pending database migrations (rockhopper up)
 disable-model-invocation: true
-argument-hint: [config_file]
+argument-hint: "[config_file]"
 ---
 
 Apply pending migrations using rockhopper.

--- a/.claude/skills/compile-migrations/SKILL.md
+++ b/.claude/skills/compile-migrations/SKILL.md
@@ -2,7 +2,7 @@
 name: compile-migrations
 description: Compile SQL migration files into Go source code for embedding in binaries
 disable-model-invocation: true
-argument-hint: [output_dir]
+argument-hint: "[output_dir]"
 ---
 
 Compile SQL migrations into Go code for all configured dialects.

--- a/.claude/skills/create-migration/SKILL.md
+++ b/.claude/skills/create-migration/SKILL.md
@@ -3,7 +3,7 @@ name: create-migration
 description: Create new SQL migration files for multiple database dialects (sqlite3, mysql, postgres, tidb, redshift, clickhouse)
 disable-model-invocation: true
 allowed-tools: Bash
-argument-hint: [migration_name]
+argument-hint: "[migration_name]"
 ---
 
 Create new migration files named `$ARGUMENTS` for all configured database dialects.

--- a/.claude/skills/migration-status/SKILL.md
+++ b/.claude/skills/migration-status/SKILL.md
@@ -2,7 +2,7 @@
 name: migration-status
 description: Show the current migration status for all configured databases
 disable-model-invocation: true
-argument-hint: [config_file]
+argument-hint: "[config_file]"
 ---
 
 Show migration status using rockhopper.

--- a/.claude/skills/rollback-migration/SKILL.md
+++ b/.claude/skills/rollback-migration/SKILL.md
@@ -2,7 +2,7 @@
 name: rollback-migration
 description: Rollback the last applied database migration (rockhopper down)
 disable-model-invocation: true
-argument-hint: [config_file]
+argument-hint: "[config_file]"
 ---
 
 Rollback the last applied migration using rockhopper.


### PR DESCRIPTION
## Summary

The bundled Claude Code skills under `.claude/skills/*/SKILL.md` (embedded into the binary via `//go:embed all:.claude/skills` in `skills.go`, and scaffolded into downstream projects by `rockhopper skills install`) declare `argument-hint` with an unquoted bracket, e.g.:

```yaml
argument-hint: [migration_name]
```

YAML parses that as a single-element sequence (`["migration_name"]`), not a string. That was tolerated by earlier tooling, but **GitHub Copilot CLI 1.0.65** tightened its frontmatter validation and now rejects any skill whose `argument-hint` is not a string. So the moment a user runs `rockhopper skills install` inside a repo that also uses Copilot CLI, all five skills fail to load.

The same latent bug exists across the Claude Code ecosystem — see [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161) — because Claude Code silently accepts the array form.

## Fix

Quote the value on all five bundled skills. YAML now parses it as a plain string, and the human-readable `[placeholder]` rendering is preserved:

```yaml
argument-hint: "[migration_name]"
```

Files changed:

- `.claude/skills/apply-migrations/SKILL.md`
- `.claude/skills/compile-migrations/SKILL.md`
- `.claude/skills/create-migration/SKILL.md`
- `.claude/skills/migration-status/SKILL.md`
- `.claude/skills/rollback-migration/SKILL.md`

## Test plan

- [x] `grep -rEn "^argument-hint:" .claude/skills` — every match is now a quoted string
- [x] Frontmatter still parses cleanly as YAML (values are plain strings; no escaping needed since none of the placeholders contain double-quotes)
- [x] Placeholders still render as `[migration_name]` / `[config_file]` / `[output_dir]` in slash-command UI
- [x] `go test ./...` — `TestInstallSkills` continues to pass (skill install still succeeds; only the embedded content changed)
- [x] Manual: `rockhopper skills install` in a repo using Copilot CLI 1.0.65 — skills load without frontmatter errors